### PR TITLE
Add 5 design variants under /variants for IT-focused redesign exploration

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -155,8 +155,13 @@ export default function Home() {
         </div>
       </section>
 
-      <footer className="text-center py-8 text-xs text-slate-600 border-t border-slate-800">
-        © 2025 Yasuaki Maruyama · Built with Next.js + TypeScript
+      <footer className="text-center py-8 text-xs text-slate-600 border-t border-slate-800 space-y-2">
+        <div>© 2025 Yasuaki Maruyama · Built with Next.js + TypeScript</div>
+        <div>
+          <a href="/variants" className="text-slate-500 hover:text-cyan-400 transition-colors">
+            ⌥ Design Variants (preview 5 candidates) →
+          </a>
+        </div>
       </footer>
     </>
   );

--- a/app/variants/brutalist/brutalist.css
+++ b/app/variants/brutalist/brutalist.css
@@ -1,0 +1,98 @@
+.brutal {
+  --ink: #0a0a0a;
+  --paper: #f5f4ee;
+  --rule: #0a0a0a;
+  --link: #0033cc;
+  --visited: #551a8b;
+  --accent: #c8102e;
+
+  background: var(--paper);
+  color: var(--ink);
+  font-family: ui-monospace, "SFMono-Regular", "JetBrains Mono", "Fira Mono", "Geist Mono", monospace;
+  font-size: 15px;
+  line-height: 1.55;
+  font-feature-settings: "ss01", "zero";
+}
+
+.brutal a { color: var(--link); text-underline-offset: 3px; }
+.brutal a:visited { color: var(--visited); }
+.brutal a:hover { background: var(--ink); color: var(--paper); text-decoration: none; }
+
+.brutal h1 {
+  font-size: clamp(2.2rem, 5vw, 3.5rem);
+  letter-spacing: -0.02em;
+  line-height: 1.05;
+  margin: 0 0 0.4em;
+}
+.brutal h2 {
+  font-size: 1.05rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  margin: 2.5rem 0 0.6rem;
+  border-top: 2px solid var(--rule);
+  padding-top: 0.6rem;
+}
+.brutal h3 {
+  font-size: 0.95rem;
+  margin: 1.4rem 0 0.3rem;
+  font-weight: 700;
+}
+
+.brutal hr { border: 0; border-top: 1px solid var(--rule); margin: 1.2rem 0; }
+.brutal mark { background: var(--accent); color: var(--paper); padding: 0 4px; }
+.brutal code { background: rgba(0,0,0,0.07); padding: 1px 4px; border-radius: 0; }
+.brutal kbd {
+  border: 1px solid var(--ink);
+  padding: 0 5px;
+  font-size: 0.85em;
+  background: var(--paper);
+}
+
+.brutal-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0;
+}
+@media (min-width: 768px) {
+  .brutal-grid { grid-template-columns: 220px 1fr; gap: 2.5rem; }
+}
+
+.brutal-toc { position: sticky; top: 1rem; align-self: start; font-size: 0.85rem; }
+.brutal-toc ol { padding-left: 1.2rem; margin: 0.5rem 0 0; }
+.brutal-toc li { margin-bottom: 0.2rem; }
+
+.brutal-tag {
+  display: inline-block;
+  padding: 0 6px;
+  border: 1px solid var(--ink);
+  font-size: 0.78em;
+  margin: 0 4px 4px 0;
+  white-space: nowrap;
+}
+
+.brutal-meta { color: #555; font-size: 0.85em; }
+
+.brutal table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.92rem;
+  margin: 0.6rem 0;
+}
+.brutal th, .brutal td {
+  border: 1px solid var(--ink);
+  padding: 4px 8px;
+  text-align: left;
+  vertical-align: top;
+}
+.brutal th { background: var(--ink); color: var(--paper); font-weight: 700; }
+
+.brutal-footnotes { font-size: 0.85em; color: #333; margin-top: 3rem; }
+.brutal-footnotes ol { padding-left: 1.4rem; }
+
+@media print {
+  .brutal { background: #fff; color: #000; }
+  .brutal a { color: #000; text-decoration: underline; }
+  .brutal a:hover { background: transparent; color: #000; }
+  .brutal h2 { border-top: 1px solid #000; }
+  nav, .no-print { display: none !important; }
+}

--- a/app/variants/brutalist/page.tsx
+++ b/app/variants/brutalist/page.tsx
@@ -1,0 +1,223 @@
+import Link from "next/link";
+import { translations, researchData, stackData } from "@/lib/i18n";
+import "./brutalist.css";
+
+export const metadata = {
+  title: "Yasuaki Maruyama — README",
+  description: "Brutalist high-density variant: README-style portfolio.",
+};
+
+const t = translations.ja;
+
+const links = [
+  { label: "GitHub", url: "https://github.com/maruyamayasuaki" },
+  { label: "Qiita", url: "https://qiita.com/yasu_qita" },
+  { label: "Email", url: "mailto:yasuuuuu0898@gmail.com" },
+];
+
+export default function BrutalistVariant() {
+  return (
+    <main className="brutal min-h-screen">
+      <div className="max-w-5xl mx-auto px-6 pt-12 pb-16">
+        <header>
+          <p className="brutal-meta">~ / portfolio / README.md · last updated 2026-04</p>
+          <h1>
+            Yasuaki Maruyama <mark>Material Informatics × ML</mark>
+          </h1>
+          <p>
+            京都大学大学院工学研究科 博士課程 1 年。能動学習と第一原理計算を用いた
+            ひずみ設計を研究。<br />
+            <a href="https://www.athenatech.io/" target="_blank" rel="noreferrer">Athena Technologies</a>{" "}
+            にて ML エンジニア (2024-11–) として、銀行・製造・医療向け AI を構築。
+          </p>
+          <p className="brutal-meta">
+            {links.map((l, i) => (
+              <span key={l.url}>
+                {i > 0 && " · "}
+                <a href={l.url} target={l.url.startsWith("mailto") ? undefined : "_blank"} rel="noreferrer">
+                  {l.label}
+                </a>
+              </span>
+            ))}
+          </p>
+        </header>
+
+        <div className="brutal-grid">
+          <aside className="brutal-toc no-print">
+            <strong>CONTENTS</strong>
+            <ol>
+              <li><a href="#about">About</a></li>
+              <li><a href="#experience">Experience</a></li>
+              <li><a href="#research">Research</a></li>
+              <li><a href="#projects">Projects</a></li>
+              <li><a href="#stack">Stack</a></li>
+              <li><a href="#beyond">Beyond</a></li>
+            </ol>
+            <hr />
+            <p className="brutal-meta">
+              <kbd>Ctrl</kbd>+<kbd>P</kbd> で印刷可。<br />
+              モノスペース、装飾なし、JS なし。
+            </p>
+          </aside>
+
+          <article>
+            <section id="about">
+              <h2>{"// About"}</h2>
+              <table>
+                <tbody>
+                  {t.about.cards.map((c) => (
+                    <tr key={c.title}>
+                      <th style={{ width: "30%" }}>{c.title}</th>
+                      <td>{c.body}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </section>
+
+            <section id="experience">
+              <h2>{"// Experience @ Athena Technologies (2024-11–)"}</h2>
+              {t.exp.items.map((item, i) => (
+                <div key={item.title}>
+                  <h3>
+                    [{i + 1}] {item.title}
+                  </h3>
+                  <p>{item.body}</p>
+                  <p>
+                    {item.tags.map((tag) => (
+                      <span key={tag} className="brutal-tag">{tag}</span>
+                    ))}
+                  </p>
+                  {item.links.length > 0 && (
+                    <p className="brutal-meta">
+                      {item.links.map((l, j) => (
+                        <span key={l.url}>
+                          {j > 0 && " · "}
+                          <a href={l.url} target="_blank" rel="noreferrer">
+                            [ref] {l.label.replace(" →", "")}
+                          </a>
+                        </span>
+                      ))}
+                    </p>
+                  )}
+                </div>
+              ))}
+            </section>
+
+            <section id="research">
+              <h2>{"// Research"}</h2>
+              <h3>Awards / Scholarships</h3>
+              <ul>
+                {researchData.awards.map((a, i) => {
+                  const title = "title" in a ? a.title : a.titleJa;
+                  return (
+                    <li key={i}>
+                      <strong>[{a.type}]</strong> {title} <span className="brutal-meta">— {a.meta}</span>
+                    </li>
+                  );
+                })}
+              </ul>
+
+              <h3>Papers</h3>
+              <ol>
+                {researchData.papers.map((p, i) => {
+                  const title = "title" in p ? p.title : p.titleJa;
+                  return (
+                    <li key={i}>
+                      {title}.{" "}
+                      <span className="brutal-meta" dangerouslySetInnerHTML={{ __html: p.authors }} />.{" "}
+                      <em>{p.journal}</em> ({p.year}).
+                    </li>
+                  );
+                })}
+              </ol>
+
+              <h3>Conferences</h3>
+              <ol>
+                {researchData.conferences.map((c, i) => {
+                  const title = "title" in c ? c.title : c.titleJa;
+                  return (
+                    <li key={i}>
+                      {title}
+                      {c.award && <> <mark>★ Best Presentation</mark></>}.{" "}
+                      <span className="brutal-meta" dangerouslySetInnerHTML={{ __html: c.authors }} />.{" "}
+                      <em>{c.venue}</em>, {c.date}. <span className="brutal-meta">[{c.type}]</span>
+                    </li>
+                  );
+                })}
+              </ol>
+            </section>
+
+            <section id="projects">
+              <h2>{"// Projects"}</h2>
+              <table>
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>What</th>
+                    <th>Stack</th>
+                    <th>Link</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {t.projects.items.map((p) => (
+                    <tr key={p.title}>
+                      <td><strong>{p.title}</strong></td>
+                      <td>{p.body}</td>
+                      <td className="brutal-meta">{p.tags.join(", ")}</td>
+                      <td>
+                        {p.link ? (
+                          <a href={p.link.url} target="_blank" rel="noreferrer">
+                            {p.link.label.replace(" →", "")}
+                          </a>
+                        ) : (
+                          <span className="brutal-meta">—</span>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </section>
+
+            <section id="stack">
+              <h2>{"// Stack"}</h2>
+              <table>
+                <tbody>
+                  {stackData.map((row) => (
+                    <tr key={row.category}>
+                      <th style={{ width: "25%" }}>{row.category}</th>
+                      <td>{row.items.join(" · ")}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </section>
+
+            <section id="beyond">
+              <h2>{"// Beyond Engineering"}</h2>
+              <ul>
+                {t.beyond.items.map((b) => (
+                  <li key={b.title}>
+                    <strong>{b.title}.</strong> {b.body}
+                    {b.link && (
+                      <> · <a href={b.link.url} target="_blank" rel="noreferrer">{b.link.label.replace(" →", "")}</a></>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </section>
+
+            <footer className="brutal-footnotes">
+              <hr />
+              <p>
+                © 2025 Yasuaki Maruyama. Plain HTML + CSS, no JS. Lighthouse-friendly.
+                {" "}<Link href="/">[home]</Link> · <Link href="/variants">[variants]</Link>
+              </p>
+            </footer>
+          </article>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/variants/cli/page.tsx
+++ b/app/variants/cli/page.tsx
@@ -1,0 +1,144 @@
+import Link from "next/link";
+import Terminal from "@/components/variants/cli/Terminal";
+import { translations, researchData } from "@/lib/i18n";
+
+export const metadata = {
+  title: "CLI Variant — Yasuaki Maruyama",
+  description: "Terminal-style portfolio variant.",
+};
+
+const t = translations.ja;
+
+export default function CLIVariant() {
+  return (
+    <main className="min-h-screen bg-[#03060c] text-slate-200 font-mono">
+      {/* CRT scanlines */}
+      <div
+        aria-hidden
+        className="pointer-events-none fixed inset-0 z-0 opacity-[0.06]"
+        style={{
+          backgroundImage:
+            "repeating-linear-gradient(0deg, rgba(255,255,255,0.6) 0 1px, transparent 1px 3px)",
+        }}
+      />
+
+      <div className="relative z-10 max-w-5xl mx-auto px-4 md:px-6 pt-20 pb-16">
+        <header className="mb-6">
+          <p className="text-xs text-emerald-400/80">{`> session: tty/portfolio · variant: A — CLI`}</p>
+          <h1 className="text-2xl md:text-3xl font-bold text-emerald-300 mt-1">
+            yasuaki@kyoto-u <span className="text-slate-500">~</span>
+          </h1>
+        </header>
+
+        <Terminal />
+
+        {/* Static fallback content (also visible after the typing finishes) */}
+        <section id="experience" className="mt-16 grid gap-6">
+          <h2 className="text-emerald-300 text-sm tracking-widest uppercase">
+            {`// experience.log`}
+          </h2>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {t.exp.items.map((e, i) => (
+              <article
+                key={e.title}
+                className="border border-emerald-500/20 bg-black/40 p-4 rounded-md hover:border-emerald-400/60 transition-colors"
+              >
+                <p className="text-emerald-400/80 text-xs">[{String(i + 1).padStart(2, "0")}]</p>
+                <h3 className="text-slate-100 font-bold mt-1 text-sm">{e.title}</h3>
+                <p className="text-slate-400 text-xs leading-relaxed mt-2">{e.body}</p>
+                <p className="mt-3 text-amber-300/90 text-[10px] tracking-wider">
+                  {e.tags.map((tag) => `#${tag.toLowerCase().replace(/\s+/g, "_")}`).join(" ")}
+                </p>
+                {e.links.length > 0 && (
+                  <p className="mt-2 text-xs">
+                    {e.links.map((l, j) => (
+                      <span key={l.url}>
+                        {j > 0 && <span className="text-slate-600"> · </span>}
+                        <a className="text-sky-400 hover:text-sky-300 underline-offset-4 hover:underline" href={l.url} target="_blank" rel="noreferrer">
+                          {`>> `}{l.label.replace(" →", "")}
+                        </a>
+                      </span>
+                    ))}
+                  </p>
+                )}
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section id="research" className="mt-16">
+          <h2 className="text-emerald-300 text-sm tracking-widest uppercase mb-3">
+            {`// research/papers.bib`}
+          </h2>
+          <div className="border border-emerald-500/20 bg-black/40 p-4 rounded-md text-xs leading-relaxed">
+            {researchData.papers.map((p, i) => {
+              const title = "title" in p ? p.title : p.titleEn;
+              return (
+                <pre key={i} className="whitespace-pre-wrap text-slate-300 mb-3">
+                  <span className="text-amber-300">@article</span>
+                  <span className="text-slate-500">{`{`}</span>
+                  <span className="text-emerald-300">paper{i + 1}</span>
+                  <span className="text-slate-500">,</span>
+                  {"\n  "}<span className="text-cyan-300">title</span>
+                  <span className="text-slate-500"> = </span>
+                  <span className="text-slate-100">{`"${title}"`}</span>
+                  <span className="text-slate-500">,</span>
+                  {"\n  "}<span className="text-cyan-300">journal</span>
+                  <span className="text-slate-500"> = </span>
+                  <span className="text-slate-100">{`"${p.journal}"`}</span>
+                  <span className="text-slate-500">,</span>
+                  {"\n  "}<span className="text-cyan-300">year</span>
+                  <span className="text-slate-500"> = </span>
+                  <span className="text-slate-100">{`{${p.year}}`}</span>
+                  {"\n"}<span className="text-slate-500">{`}`}</span>
+                </pre>
+              );
+            })}
+          </div>
+        </section>
+
+        <section id="projects" className="mt-16">
+          <h2 className="text-emerald-300 text-sm tracking-widest uppercase mb-3">
+            {`// ls projects/`}
+          </h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            {t.projects.items.map((p) => (
+              <article key={p.title} className="border border-emerald-500/20 bg-black/40 p-4 rounded-md hover:border-emerald-400/60 transition-colors">
+                <p className="text-amber-300 text-xs">{`drwxr-xr-x  yasuaki  ${p.tags.join(" · ")}`}</p>
+                <h3 className="text-slate-100 font-bold mt-1">{p.title}/</h3>
+                <p className="text-slate-400 text-xs mt-2 leading-relaxed">{p.body}</p>
+                {p.link && (
+                  <a className="block mt-3 text-sky-400 text-xs hover:text-sky-300 hover:underline" href={p.link.url} target="_blank" rel="noreferrer">
+                    {`$ open `}{p.link.url}
+                  </a>
+                )}
+              </article>
+            ))}
+          </div>
+        </section>
+
+        <section id="contact" className="mt-16">
+          <h2 className="text-emerald-300 text-sm tracking-widest uppercase mb-3">
+            {`// contact --send`}
+          </h2>
+          <div className="border border-emerald-500/20 bg-black/40 p-4 rounded-md text-sm flex flex-wrap gap-3">
+            <a className="text-sky-400 hover:text-sky-300 hover:underline" href="https://github.com/maruyamayasuaki" target="_blank" rel="noreferrer">$ ssh github.com/maruyamayasuaki</a>
+            <span className="text-slate-600">|</span>
+            <a className="text-sky-400 hover:text-sky-300 hover:underline" href="https://qiita.com/yasu_qita" target="_blank" rel="noreferrer">$ curl qiita.com/yasu_qita</a>
+            <span className="text-slate-600">|</span>
+            <a className="text-sky-400 hover:text-sky-300 hover:underline" href="mailto:yasuuuuu0898@gmail.com">$ mail yasuuuuu0898@gmail.com</a>
+          </div>
+        </section>
+
+        <footer className="mt-16 text-xs text-slate-500 border-t border-emerald-500/10 pt-4 flex justify-between">
+          <span>EOF — © 2025 Yasuaki Maruyama</span>
+          <span>
+            <Link href="/" className="hover:text-emerald-300">/home</Link>
+            <span className="text-slate-700"> · </span>
+            <Link href="/variants" className="hover:text-emerald-300">/variants</Link>
+          </span>
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/app/variants/dashboard/page.tsx
+++ b/app/variants/dashboard/page.tsx
@@ -1,0 +1,216 @@
+import Link from "next/link";
+import { translations, researchData, stackData } from "@/lib/i18n";
+import githubStats from "@/lib/github-stats.json";
+import LangDonut from "@/components/variants/dashboard/LangDonut";
+import Heatmap from "@/components/variants/dashboard/Heatmap";
+import SkillRadar from "@/components/variants/dashboard/SkillRadar";
+import BibtexButton from "@/components/variants/dashboard/BibtexButton";
+
+export const metadata = {
+  title: "Dashboard Variant — Yasuaki Maruyama",
+  description: "GitHub-style data dashboard variant.",
+};
+
+const t = translations.ja;
+
+const skills = [
+  { label: "Python", value: 92 },
+  { label: "ML/AI", value: 88 },
+  { label: "TS/Next", value: 80 },
+  { label: "DFT", value: 78 },
+  { label: "Bayes Opt", value: 85 },
+  { label: "Cloud", value: 70 },
+  { label: "Writing", value: 75 },
+];
+
+function fmtDate(iso: string | null | undefined) {
+  if (!iso) return "—";
+  return new Date(iso).toISOString().slice(0, 10);
+}
+
+function bibtexFor(p: typeof researchData.papers[number], i: number) {
+  const title = "title" in p ? p.title : p.titleEn;
+  const authors = p.authors.replace(/<\/?b>/g, "");
+  return `@article{maruyama${p.year}_${i},
+  title   = {${title}},
+  author  = {${authors}},
+  journal = {${p.journal}},
+  year    = {${p.year}},
+}`;
+}
+
+export default function DashboardVariant() {
+  const langs = githubStats.languages as Record<string, number>;
+  const totalRepos = githubStats.totals.repos;
+  const totalStars = githubStats.totals.stars;
+  const featured = githubStats.featured as Array<{
+    name: string;
+    description: string | null;
+    url: string;
+    stars: number;
+    forks: number;
+    language: string | null;
+    updated: string | null;
+    topics: string[];
+  }>;
+
+  return (
+    <main className="min-h-screen bg-[#0d1117] text-slate-200">
+      <div className="max-w-6xl mx-auto px-5 md:px-8 pt-16 pb-14">
+        {/* Header */}
+        <header className="flex flex-col md:flex-row md:items-end gap-6 pb-6 border-b border-white/10">
+          <div className="flex items-center gap-4">
+            {/* Avatar */}
+            <div className="w-20 h-20 rounded-full overflow-hidden ring-2 ring-cyan-500/40 bg-slate-800 flex-shrink-0">
+              {githubStats.user.avatarUrl ? (
+                /* eslint-disable-next-line @next/next/no-img-element */
+                <img src={githubStats.user.avatarUrl} alt="" className="w-full h-full object-cover" />
+              ) : null}
+            </div>
+            <div>
+              <h1 className="text-2xl md:text-3xl font-bold text-white">
+                {githubStats.user.name || "Yasuaki Maruyama"}
+                <span className="ml-2 text-slate-500 font-normal text-base">@{githubStats.user.login}</span>
+              </h1>
+              <p className="text-sm text-slate-400 mt-1">{t.hero.kicker}</p>
+              <p className="text-xs text-slate-500 mt-1">
+                {githubStats.user.bio || "Bridging materials science and AI."}
+              </p>
+            </div>
+          </div>
+          <div className="md:ml-auto flex gap-6 text-sm">
+            <div>
+              <div className="text-2xl font-bold text-white tabular-nums">{totalRepos}</div>
+              <div className="text-xs text-slate-400">repos</div>
+            </div>
+            <div>
+              <div className="text-2xl font-bold text-white tabular-nums">{totalStars}</div>
+              <div className="text-xs text-slate-400">★ stars</div>
+            </div>
+            <div>
+              <div className="text-2xl font-bold text-white tabular-nums">{githubStats.user.followers}</div>
+              <div className="text-xs text-slate-400">followers</div>
+            </div>
+            <div>
+              <div className="text-2xl font-bold text-white tabular-nums">{researchData.papers.length}</div>
+              <div className="text-xs text-slate-400">papers</div>
+            </div>
+          </div>
+        </header>
+
+        {/* Top row */}
+        <section className="grid grid-cols-1 lg:grid-cols-3 gap-5 mt-8">
+          <div className="lg:col-span-2 rounded-lg border border-white/10 bg-[#161b22] p-5">
+            <h2 className="text-sm font-semibold text-slate-200 mb-3 flex items-center gap-2">
+              <span className="text-emerald-400">●</span> Contribution heatmap
+            </h2>
+            <Heatmap />
+          </div>
+          <div className="rounded-lg border border-white/10 bg-[#161b22] p-5">
+            <h2 className="text-sm font-semibold text-slate-200 mb-4">Top languages</h2>
+            <LangDonut data={langs} />
+          </div>
+        </section>
+
+        {/* Repos + Radar */}
+        <section className="grid grid-cols-1 lg:grid-cols-3 gap-5 mt-5">
+          <div className="lg:col-span-2 rounded-lg border border-white/10 bg-[#161b22] p-5">
+            <h2 className="text-sm font-semibold text-slate-200 mb-3">Pinned repositories</h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              {featured.slice(0, 6).map((r) => (
+                <a
+                  key={r.name}
+                  href={r.url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="block p-3 rounded-md border border-white/10 hover:border-cyan-500/50 hover:bg-white/[0.02] transition-colors"
+                >
+                  <div className="flex items-baseline justify-between gap-2">
+                    <span className="text-cyan-300 font-semibold text-sm truncate">{r.name}</span>
+                    <span className="text-[10px] text-slate-500 tabular-nums whitespace-nowrap">
+                      ★ {r.stars} · ⑂ {r.forks}
+                    </span>
+                  </div>
+                  <p className="text-xs text-slate-400 mt-1 line-clamp-2 min-h-[2.4em]">
+                    {r.description || "—"}
+                  </p>
+                  <div className="flex items-center gap-2 mt-2 text-[10px] text-slate-500">
+                    {r.language && <span>● {r.language}</span>}
+                    <span>updated {fmtDate(r.updated)}</span>
+                  </div>
+                </a>
+              ))}
+            </div>
+          </div>
+          <div className="rounded-lg border border-white/10 bg-[#161b22] p-5 flex flex-col items-center">
+            <h2 className="text-sm font-semibold text-slate-200 mb-3 self-start">Skill radar</h2>
+            <SkillRadar skills={skills} />
+            <div className="mt-3 grid grid-cols-2 gap-x-4 gap-y-1 text-[10px] text-slate-400 w-full">
+              {stackData.flatMap((s) => s.items).slice(0, 12).map((it) => (
+                <div key={it} className="flex items-center gap-1">
+                  <span className="text-cyan-400">●</span> {it}
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Experience timeline */}
+        <section className="mt-5 rounded-lg border border-white/10 bg-[#161b22] p-5">
+          <h2 className="text-sm font-semibold text-slate-200 mb-4">Experience @ Athena Technologies</h2>
+          <ol className="relative border-l border-cyan-500/30 ml-2">
+            {t.exp.items.map((e, i) => (
+              <li key={e.title} className="ml-6 pb-5 last:pb-0">
+                <span className="absolute -left-[7px] mt-1 w-3 h-3 rounded-full bg-cyan-400 ring-4 ring-cyan-400/20" />
+                <p className="text-[10px] uppercase tracking-wider text-cyan-300">{`#${i + 1}`}</p>
+                <h3 className="text-white font-semibold text-sm mt-0.5">{e.title}</h3>
+                <p className="text-slate-400 text-xs leading-relaxed mt-1">{e.body}</p>
+                <div className="flex flex-wrap gap-1.5 mt-2">
+                  {e.tags.map((tag) => (
+                    <span key={tag} className="text-[10px] px-1.5 py-0.5 rounded bg-cyan-500/10 text-cyan-300 border border-cyan-500/20">
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              </li>
+            ))}
+          </ol>
+        </section>
+
+        {/* Papers with BibTeX */}
+        <section className="mt-5 rounded-lg border border-white/10 bg-[#161b22] p-5">
+          <h2 className="text-sm font-semibold text-slate-200 mb-4">Publications</h2>
+          <ul className="space-y-3">
+            {researchData.papers.map((p, i) => {
+              const title = "title" in p ? p.title : p.titleEn;
+              return (
+                <li key={i} className="border-l-2 border-purple-500/40 pl-3">
+                  <div className="flex items-start gap-2 justify-between">
+                    <p className="text-white text-sm">{title}</p>
+                    <BibtexButton bibtex={bibtexFor(p, i)} />
+                  </div>
+                  <p className="text-xs text-slate-400 mt-1" dangerouslySetInnerHTML={{ __html: p.authors }} />
+                  <p className="text-[10px] text-slate-500 mt-0.5 italic">
+                    {p.journal} · {p.year}
+                  </p>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+
+        <footer className="mt-10 flex justify-between text-xs text-slate-500 border-t border-white/10 pt-4">
+          <span>
+            Generated{" "}
+            {githubStats.generatedAt ? fmtDate(githubStats.generatedAt) : "—"} · Variant C
+          </span>
+          <span>
+            <Link href="/" className="hover:text-cyan-400">/</Link>
+            <span className="text-slate-700"> · </span>
+            <Link href="/variants" className="hover:text-cyan-400">/variants</Link>
+          </span>
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/app/variants/ide/page.tsx
+++ b/app/variants/ide/page.tsx
@@ -1,0 +1,196 @@
+import { codeToHtml } from "shiki";
+import { translations, researchData, stackData } from "@/lib/i18n";
+import IdeShell, { type IdeFile } from "@/components/variants/ide/IdeShell";
+import "@/components/variants/ide/ide.css";
+import Link from "next/link";
+
+export const metadata = {
+  title: "IDE Variant — Yasuaki Maruyama",
+  description: "VSCode-style IDE variant of the portfolio.",
+};
+
+const t = translations.ja;
+
+const aboutMd = `# Yasuaki Maruyama
+
+> Material Informatics × ML Engineer
+> Kyoto University · Athena Technologies
+
+## Profile
+${t.hero.lead}
+
+## Currently
+- 京都大学大学院工学研究科 博士課程 1 年
+- ML Engineer @ Athena Technologies (2024-11–)
+- Bayesian active learning × first-principles DFT
+
+## Reach me
+- GitHub : https://github.com/maruyamayasuaki
+- Qiita  : https://qiita.com/yasu_qita
+- Email  : yasuuuuu0898@gmail.com
+`;
+
+const experienceTsx = `import type { Project } from "./types";
+
+/**
+ * Industrial AI delivered at Athena Technologies (2024-11–).
+ * Each entry is one revenue-bearing engagement.
+ */
+export const experience: Project[] = [
+${t.exp.items
+  .map(
+    (e, i) => `  {
+    id: ${i + 1},
+    title: ${JSON.stringify(e.title)},
+    summary: ${JSON.stringify(e.body)},
+    tags: [${e.tags.map((tag) => `"${tag}"`).join(", ")}],
+    links: [${e.links.map((l) => `"${l.url}"`).join(", ")}],
+  }`,
+  )
+  .join(",\n")}
+];
+
+export const isImpactful = (p: Project) =>
+  p.tags.some((t) => ["FinTech", "HealthTech", "Manufacturing"].includes(t));
+`;
+
+const projectsJson = JSON.stringify(
+  {
+    featured: t.projects.items.map((p) => ({
+      title: p.title,
+      summary: p.body,
+      stack: p.tags,
+      url: p.link?.url ?? null,
+    })),
+    stack: stackData.reduce((acc, s) => ({ ...acc, [s.category]: s.items }), {}),
+  },
+  null,
+  2,
+);
+
+const researchBib = researchData.papers
+  .map((p, i) => {
+    const title = "title" in p ? p.title : p.titleEn;
+    const authors = p.authors.replace(/<\/?b>/g, "");
+    return `@article{maruyama${p.year}_${i},
+  title   = {${title}},
+  author  = {${authors}},
+  journal = {${p.journal}},
+  year    = {${p.year}},
+}`;
+  })
+  .join("\n\n");
+
+const stackPy = `# stack.py — research + production runtime
+from __future__ import annotations
+
+LANGUAGES = ${JSON.stringify(stackData[0].items)}
+ML        = ${JSON.stringify(stackData[1].items)}
+WEB       = ${JSON.stringify(stackData[2].items)}
+RESEARCH  = ${JSON.stringify(stackData[3].items)}
+
+def daily() -> dict[str, list[str]]:
+    """A typical workday spans these tools."""
+    return {
+        "morning":   ["Python", "PyTorch", "Active Learning"],
+        "afternoon": ["TypeScript", "Next.js", "AWS"],
+        "evening":   ["First-principles DFT", "Bayesian Opt"],
+    }
+
+if __name__ == "__main__":
+    for shift, tools in daily().items():
+        print(f"{shift:>9}: {', '.join(tools)}")
+`;
+
+async function buildFiles(): Promise<IdeFile[]> {
+  const theme = "github-dark-default";
+
+  const renders = await Promise.all([
+    codeToHtml(aboutMd, { lang: "markdown", theme }),
+    codeToHtml(experienceTsx, { lang: "tsx", theme }),
+    codeToHtml(projectsJson, { lang: "json", theme }),
+    codeToHtml(researchBib, { lang: "bibtex", theme }),
+    codeToHtml(stackPy, { lang: "python", theme }),
+  ]);
+
+  return [
+    {
+      id: "about",
+      label: "about.md",
+      icon: "⌘",
+      iconColor: "text-sky-400",
+      language: "Markdown",
+      highlighted: renders[0],
+      raw: aboutMd,
+    },
+    {
+      id: "experience",
+      label: "experience.tsx",
+      icon: "⟨⟩",
+      iconColor: "text-blue-400",
+      language: "TypeScript React",
+      highlighted: renders[1],
+      raw: experienceTsx,
+    },
+    {
+      id: "projects",
+      label: "projects.json",
+      icon: "{}",
+      iconColor: "text-amber-400",
+      language: "JSON",
+      highlighted: renders[2],
+      raw: projectsJson,
+    },
+    {
+      id: "research",
+      label: "research.bib",
+      icon: "Σ",
+      iconColor: "text-violet-400",
+      language: "BibTeX",
+      highlighted: renders[3],
+      raw: researchBib,
+    },
+    {
+      id: "stack",
+      label: "stack.py",
+      icon: "🐍",
+      iconColor: "",
+      language: "Python",
+      highlighted: renders[4],
+      raw: stackPy,
+    },
+  ];
+}
+
+export default async function IDEVariant() {
+  const files = await buildFiles();
+
+  return (
+    <main className="min-h-screen bg-[#1e1e1e] text-slate-200">
+      <div className="max-w-7xl mx-auto px-3 md:px-6 pt-16 pb-10">
+        <header className="mb-4 flex items-baseline gap-3 flex-wrap">
+          <h1 className="text-xl md:text-2xl font-semibold text-white font-mono">
+            <span className="text-slate-500">~/</span>portfolio
+          </h1>
+          <span className="text-xs text-slate-500 font-mono">— Variant B · IDE / VSCode</span>
+        </header>
+
+        <IdeShell files={files} />
+
+        <p className="mt-4 text-xs text-slate-500 font-mono">
+          ヒント: ファイルツリーから別の「ファイル」を開いて見比べてください。
+          シンタックスハイライトはビルド時に <code>shiki</code> で実行され、クライアントには文字列のみ送られます。
+        </p>
+
+        <footer className="mt-12 text-xs text-slate-500 font-mono flex justify-between border-t border-white/10 pt-4">
+          <span>© 2025 Yasuaki Maruyama · Variant B</span>
+          <span>
+            <Link href="/" className="hover:text-cyan-400">/</Link>
+            <span className="text-slate-700"> · </span>
+            <Link href="/variants" className="hover:text-cyan-400">/variants</Link>
+          </span>
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/app/variants/layout.tsx
+++ b/app/variants/layout.tsx
@@ -1,0 +1,29 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Design Variants | Yasuaki Maruyama",
+  description: "Five candidate redesigns of the portfolio site, side by side.",
+};
+
+export default function VariantsLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen flex flex-col">
+      <div className="fixed top-3 left-3 z-50 flex gap-2 text-xs">
+        <Link
+          href="/variants"
+          className="px-2.5 py-1 rounded-md bg-black/70 backdrop-blur border border-white/15 text-slate-200 hover:border-cyan-400 hover:text-cyan-400 transition-colors"
+        >
+          ← Variants
+        </Link>
+        <Link
+          href="/"
+          className="px-2.5 py-1 rounded-md bg-black/70 backdrop-blur border border-white/15 text-slate-200 hover:border-cyan-400 hover:text-cyan-400 transition-colors"
+        >
+          Original /
+        </Link>
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/app/variants/mi-lab/page.tsx
+++ b/app/variants/mi-lab/page.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import Link from "next/link";
+import { translations, researchData, stackData } from "@/lib/i18n";
+import BayesOpt1D from "@/components/variants/mi-lab/BayesOpt1D";
+
+// Three.js scene must be client-only — disable SSR for compatibility with
+// `output: "export"` static generation.
+const Lattice3D = dynamic(() => import("@/components/variants/mi-lab/Lattice3D"), {
+  ssr: false,
+  loading: () => (
+    <div className="absolute inset-0 flex items-center justify-center text-slate-500 text-xs font-mono">
+      loading lattice…
+    </div>
+  ),
+});
+
+const t = translations.ja;
+
+export default function MILabVariant() {
+  return (
+    <main className="min-h-screen bg-[#040711] text-slate-200">
+      {/* Hero with 3D lattice */}
+      <section className="relative h-[88vh] min-h-[640px] overflow-hidden">
+        <Lattice3D />
+
+        {/* Vignette + gradient overlay */}
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-0"
+          style={{
+            background:
+              "radial-gradient(ellipse at center, transparent 30%, rgba(4,7,17,0.85) 80%), linear-gradient(180deg, rgba(4,7,17,0.4), transparent 40%, rgba(4,7,17,0.95))",
+          }}
+        />
+
+        {/* Lab-notebook overlay */}
+        <div className="absolute inset-0 flex flex-col justify-end pointer-events-none">
+          <div className="max-w-5xl mx-auto w-full px-6 pb-16 pointer-events-auto">
+            <p className="text-xs tracking-[0.3em] uppercase text-cyan-400 mb-3 font-mono">
+              experiment_log_042 · PbTiO₃ · perovskite ABO₃
+            </p>
+            <h1 className="text-5xl md:text-7xl font-bold text-white mb-3 tracking-tight">
+              {t.hero.name}
+            </h1>
+            <p className="text-cyan-300 text-lg font-mono mb-3">{t.hero.kicker}</p>
+            <p className="text-slate-300 text-base md:text-lg max-w-2xl leading-relaxed">
+              {t.hero.lead}
+            </p>
+            <div className="mt-6 flex flex-wrap gap-3">
+              <a
+                href="#research"
+                className="px-5 py-2.5 rounded-md bg-gradient-to-r from-cyan-400 to-purple-500 text-white font-semibold text-sm hover:shadow-[0_0_30px_rgba(124,58,237,0.4)] transition-shadow"
+              >
+                Open lab notebook ↓
+              </a>
+              <a
+                href="https://github.com/maruyamayasuaki"
+                target="_blank"
+                rel="noreferrer"
+                className="px-5 py-2.5 rounded-md border border-white/20 text-slate-200 hover:border-cyan-400 hover:text-cyan-400 transition-colors text-sm"
+              >
+                GitHub
+              </a>
+            </div>
+            <p className="mt-5 text-[11px] text-slate-500 font-mono">
+              ▣ drag to rotate · scroll to zoom · A: Pb · B: Ti · O: oxygen octahedron
+            </p>
+          </div>
+        </div>
+
+        {/* Top legend */}
+        <div className="absolute top-20 right-6 text-xs font-mono space-y-1 bg-black/40 backdrop-blur p-3 rounded-md border border-white/10">
+          <div className="flex items-center gap-2">
+            <span className="w-2 h-2 rounded-full bg-amber-400" />
+            <span className="text-slate-300">A-site (Pb²⁺)</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="w-2 h-2 rounded-full bg-cyan-400" />
+            <span className="text-slate-300">B-site (Ti⁴⁺)</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="w-2 h-2 rounded-full bg-red-400" />
+            <span className="text-slate-300">O²⁻</span>
+          </div>
+        </div>
+      </section>
+
+      {/* Section: research highlights */}
+      <section id="research" className="px-6 py-20">
+        <div className="max-w-5xl mx-auto grid grid-cols-1 lg:grid-cols-5 gap-8">
+          <div className="lg:col-span-2">
+            <p className="text-xs tracking-[0.25em] uppercase text-cyan-400 font-mono">
+              §1 · Method
+            </p>
+            <h2 className="text-3xl font-bold text-white mt-2 mb-4">能動学習で六次元ひずみ空間を探索</h2>
+            <p className="text-slate-400 text-sm leading-relaxed">
+              第一原理計算 (DFT) は高精度ですが、評価コストが大きく
+              全探索は不可能です。Gaussian Process と Expected Improvement
+              による Bayesian Active Learning で「次に計算すべき点」を選び、
+              強誘電体 PbTiO₃ のひずみ最適化を加速しています。
+            </p>
+            <ul className="mt-4 text-xs text-slate-300 font-mono space-y-1.5">
+              <li>· DFT (VASP) × high-throughput pipeline</li>
+              <li>· 6-D strain ε ∈ ℝ⁶ search space</li>
+              <li>· GP-EI / GP-UCB 比較</li>
+              <li>· 数百点で convergence 確認</li>
+            </ul>
+          </div>
+          <div className="lg:col-span-3">
+            <BayesOpt1D />
+          </div>
+        </div>
+      </section>
+
+      {/* Experience */}
+      <section className="px-6 py-20 border-t border-white/5 bg-white/[0.015]">
+        <div className="max-w-5xl mx-auto">
+          <p className="text-xs tracking-[0.25em] uppercase text-cyan-400 font-mono mb-2">
+            §2 · Industrial AI · Athena Technologies
+          </p>
+          <h2 className="text-3xl font-bold text-white mb-8">研究で培った最適化思考を産業 AI に</h2>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-5">
+            {t.exp.items.map((e, i) => (
+              <article
+                key={e.title}
+                className="p-5 rounded-xl border border-white/10 bg-white/[0.02] hover:bg-white/[0.04] hover:border-cyan-500/40 transition-colors"
+              >
+                <p className="text-[10px] font-mono text-cyan-300">case_{String(i + 1).padStart(2, "0")}</p>
+                <h3 className="text-white font-semibold mt-1">{e.title}</h3>
+                <p className="text-slate-400 text-sm mt-2 leading-relaxed">{e.body}</p>
+                <div className="flex flex-wrap gap-1.5 mt-3">
+                  {e.tags.map((tag) => (
+                    <span key={tag} className="text-[10px] px-2 py-0.5 rounded bg-cyan-500/10 text-cyan-300 border border-cyan-500/20 font-mono">
+                      {tag}
+                    </span>
+                  ))}
+                </div>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Publications */}
+      <section className="px-6 py-20">
+        <div className="max-w-5xl mx-auto">
+          <p className="text-xs tracking-[0.25em] uppercase text-cyan-400 font-mono mb-2">
+            §3 · Publications & Conferences
+          </p>
+          <h2 className="text-3xl font-bold text-white mb-8">Peer-reviewed output</h2>
+
+          <div className="space-y-3">
+            {researchData.papers.map((p, i) => {
+              const title = "title" in p ? p.title : p.titleEn;
+              return (
+                <div
+                  key={i}
+                  className="p-4 rounded-md border-l-2 border-purple-400/60 bg-white/[0.02]"
+                >
+                  <h3 className="text-white text-sm font-semibold">{title}</h3>
+                  <p
+                    className="text-xs text-slate-400 mt-1"
+                    dangerouslySetInnerHTML={{ __html: p.authors }}
+                  />
+                  <p className="text-[11px] text-slate-500 mt-1 italic">
+                    {p.journal} · {p.year}
+                  </p>
+                </div>
+              );
+            })}
+          </div>
+
+          <h3 className="text-sm font-mono text-cyan-300 mt-10 mb-3">
+            §3.1 · Conferences
+          </h3>
+          <ul className="space-y-2 text-xs">
+            {researchData.conferences.map((c, i) => {
+              const title = "title" in c ? c.title : c.titleJa;
+              return (
+                <li key={i} className="text-slate-400 leading-relaxed">
+                  <span className="text-cyan-300 font-mono">[{c.type}]</span>{" "}
+                  <span className="text-slate-200">{title}</span>
+                  {c.award && <span className="ml-1 inline-block px-1.5 py-0.5 rounded bg-amber-500/20 text-amber-300 text-[10px]">★ Best</span>}
+                  <br />
+                  <span className="text-slate-500">{c.venue} · {c.date}</span>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      </section>
+
+      {/* Stack */}
+      <section className="px-6 py-20 border-t border-white/5 bg-white/[0.015]">
+        <div className="max-w-5xl mx-auto">
+          <p className="text-xs tracking-[0.25em] uppercase text-cyan-400 font-mono mb-2">
+            §4 · Toolchain
+          </p>
+          <h2 className="text-3xl font-bold text-white mb-8">研究 → 実装、両側を実装する</h2>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            {stackData.map((s) => (
+              <div key={s.category} className="p-4 rounded-lg border border-white/10 bg-black/20">
+                <p className="text-xs font-mono text-cyan-300 mb-2">{s.category}</p>
+                <ul className="text-sm text-slate-300 space-y-1">
+                  {s.items.map((it) => (
+                    <li key={it}>· {it}</li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <footer className="text-center py-8 text-xs text-slate-500 border-t border-white/5">
+        <p>
+          © 2025 Yasuaki Maruyama · Variant E · Built with Next.js + react-three-fiber
+        </p>
+        <p className="mt-1">
+          <Link href="/" className="hover:text-cyan-400">/</Link>
+          <span className="text-slate-700"> · </span>
+          <Link href="/variants" className="hover:text-cyan-400">/variants</Link>
+        </p>
+      </footer>
+    </main>
+  );
+}

--- a/app/variants/page.tsx
+++ b/app/variants/page.tsx
@@ -1,0 +1,203 @@
+import Link from "next/link";
+
+type Variant = {
+  slug: string;
+  letter: string;
+  name: string;
+  tagline: string;
+  audience: string[];
+  accent: string;
+  preview: React.ReactNode;
+};
+
+const variants: Variant[] = [
+  {
+    slug: "cli",
+    letter: "A",
+    name: "CLI / Terminal",
+    tagline: "$ whoami — タイプライタで語る、ハッカー寄りのターミナル UI",
+    audience: ["OSS", "シニア", "ハッカー寄り"],
+    accent: "from-emerald-400 to-amber-300",
+    preview: (
+      <pre className="font-mono text-[10px] leading-tight text-emerald-300/90">
+        <span className="text-amber-300">$</span> whoami{"\n"}
+        Yasuaki Maruyama{"\n"}
+        <span className="text-amber-300">$</span> ls projects/{"\n"}
+        local-discovery  manimtube  starbucks-map  …{"\n"}
+        <span className="text-amber-300">$</span> <span className="animate-pulse">▍</span>
+      </pre>
+    ),
+  },
+  {
+    slug: "ide",
+    letter: "B",
+    name: "IDE / VSCode",
+    tagline: "Explorer + エディタ + ステータスバー、コードで語るレイアウト",
+    audience: ["Web", "フルスタック"],
+    accent: "from-sky-400 to-indigo-400",
+    preview: (
+      <div className="font-mono text-[10px] leading-tight grid grid-cols-[60px_1fr] h-full">
+        <div className="border-r border-white/10 pr-2 text-slate-400">
+          <div>EXPLORER</div>
+          <div className="mt-1 text-cyan-300">▾ portfolio</div>
+          <div className="pl-2">about.md</div>
+          <div className="pl-2 text-amber-300">experience.tsx</div>
+          <div className="pl-2">projects.json</div>
+        </div>
+        <div className="pl-2 text-slate-300">
+          <div className="text-purple-300">{`<Section>`}</div>
+          <div className="pl-2">{`Athena Tech…`}</div>
+          <div className="text-purple-300">{`</Section>`}</div>
+        </div>
+      </div>
+    ),
+  },
+  {
+    slug: "dashboard",
+    letter: "C",
+    name: "GitHub Dashboard",
+    tagline: "実績を数値で。コントリビューション・言語比率・論文を可視化",
+    audience: ["採用", "マネージャ", "研究者"],
+    accent: "from-fuchsia-400 to-cyan-400",
+    preview: (
+      <div className="grid grid-cols-12 gap-[2px] p-1">
+        {Array.from({ length: 12 * 7 }).map((_, i) => {
+          const level = (i * 13) % 5;
+          const bg = ["bg-white/5", "bg-emerald-900/60", "bg-emerald-700/70", "bg-emerald-500/80", "bg-emerald-300"][level];
+          return <div key={i} className={`aspect-square rounded-[2px] ${bg}`} />;
+        })}
+      </div>
+    ),
+  },
+  {
+    slug: "brutalist",
+    letter: "D",
+    name: "Brutalist",
+    tagline: "装飾なし、モノスペース、高密度。中身で語る README 派",
+    audience: ["シニア", "OSS"],
+    accent: "from-white to-slate-400",
+    preview: (
+      <pre className="font-mono text-[10px] leading-tight text-white">
+        # Yasuaki Maruyama{"\n"}
+        - Material Informatics × ML{"\n"}
+        - Kyoto Univ. D1{"\n"}
+        - @ Athena Technologies{"\n"}
+        ## Papers [1] [2]{"\n"}
+        ## Stack: py, ts, rb, kt{"\n"}
+      </pre>
+    ),
+  },
+  {
+    slug: "mi-lab",
+    letter: "E",
+    name: "MI Lab — 3D",
+    tagline: "Hero に結晶格子 3D + ベイズ最適化デモ。専門性を主役に",
+    audience: ["ML", "研究者", "CTO"],
+    accent: "from-cyan-300 via-purple-400 to-fuchsia-500",
+    preview: (
+      <div className="relative h-full">
+        <svg viewBox="0 0 100 60" className="w-full h-full">
+          {[
+            [25, 15],
+            [55, 15],
+            [85, 15],
+            [10, 35],
+            [40, 35],
+            [70, 35],
+            [25, 55],
+            [55, 55],
+            [85, 55],
+          ].map(([x, y], i) => (
+            <g key={i}>
+              <circle cx={x} cy={y} r="3.5" fill="url(#g)" />
+            </g>
+          ))}
+          {[
+            [25, 15, 55, 15],
+            [55, 15, 85, 15],
+            [10, 35, 40, 35],
+            [40, 35, 70, 35],
+            [25, 55, 55, 55],
+            [55, 55, 85, 55],
+            [25, 15, 10, 35],
+            [55, 15, 40, 35],
+            [85, 15, 70, 35],
+            [10, 35, 25, 55],
+            [40, 35, 55, 55],
+            [70, 35, 85, 55],
+          ].map(([x1, y1, x2, y2], i) => (
+            <line key={i} x1={x1} y1={y1} x2={x2} y2={y2} stroke="rgba(255,255,255,0.25)" strokeWidth="0.5" />
+          ))}
+          <defs>
+            <radialGradient id="g">
+              <stop offset="0%" stopColor="#a5f3fc" />
+              <stop offset="100%" stopColor="#7c3aed" />
+            </radialGradient>
+          </defs>
+        </svg>
+      </div>
+    ),
+  },
+];
+
+export default function VariantsIndex() {
+  return (
+    <main className="min-h-screen bg-[#060912] text-slate-200 px-6 py-20">
+      <div className="max-w-5xl mx-auto">
+        <header className="mb-12 mt-8">
+          <p className="text-xs tracking-[0.2em] uppercase text-cyan-400 mb-3">Design Variants</p>
+          <h1 className="text-4xl md:text-5xl font-bold text-white mb-4">
+            5 候補を見比べる
+          </h1>
+          <p className="text-slate-400 max-w-2xl">
+            IT 系ターゲットに「刺さる」ポートフォリオの方向性を 5 案、それぞれ別ルートに実装しました。
+            実際に触ってから採用案を決めます。コンテンツは <code className="px-1 py-0.5 rounded bg-white/5 text-cyan-300 text-xs">lib/i18n.ts</code> を全案で共通利用しています。
+          </p>
+        </header>
+
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+          {variants.map((v) => (
+            <Link
+              key={v.slug}
+              href={`/variants/${v.slug}`}
+              className="group relative rounded-2xl border border-white/10 bg-white/[0.02] hover:bg-white/[0.04] hover:border-white/25 transition-all overflow-hidden"
+            >
+              <div
+                className={`absolute inset-x-0 top-0 h-0.5 bg-gradient-to-r ${v.accent} opacity-60 group-hover:opacity-100 transition-opacity`}
+              />
+              <div className="p-6 flex flex-col gap-4 h-full">
+                <div className="flex items-baseline gap-3">
+                  <span className={`text-3xl font-bold bg-gradient-to-br ${v.accent} bg-clip-text text-transparent`}>
+                    {v.letter}
+                  </span>
+                  <h2 className="text-xl font-semibold text-white">{v.name}</h2>
+                </div>
+                <p className="text-sm text-slate-400 leading-relaxed">{v.tagline}</p>
+
+                <div className="rounded-lg bg-black/40 border border-white/10 h-28 overflow-hidden">
+                  {v.preview}
+                </div>
+
+                <div className="flex flex-wrap gap-1.5 mt-auto">
+                  {v.audience.map((a) => (
+                    <span key={a} className="text-[0.65rem] px-2 py-0.5 rounded-full bg-white/5 border border-white/10 text-slate-400">
+                      {a}
+                    </span>
+                  ))}
+                </div>
+
+                <div className="text-xs text-cyan-400 group-hover:text-cyan-300 mt-1">
+                  /variants/{v.slug} →
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+
+        <footer className="mt-16 text-center text-xs text-slate-500">
+          すべて静的書き出し (Next.js 16 + React 19) で GitHub Pages にデプロイされています。
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/components/variants/cli/Terminal.tsx
+++ b/components/variants/cli/Terminal.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { translations, researchData, stackData } from "@/lib/i18n";
+
+type Line =
+  | { kind: "prompt"; cmd: string }
+  | { kind: "out"; text: string }
+  | { kind: "ascii"; text: string };
+
+const t = translations.ja;
+
+function buildScript(): Line[] {
+  const lines: Line[] = [
+    { kind: "ascii", text: "  ___                       _    _ \n / __|___ _ _ __ _ ___ _ _ | | _(_)\n \\__ \\ -_) '_/ _` / -_) ' \\| |/ / |\n |___/___|_| \\__,_\\___|_||_|_|\\_\\_|" },
+    { kind: "out", text: "Welcome. Last login: Sat 26 Apr 2026 from 192.0.2.42" },
+    { kind: "prompt", cmd: "whoami" },
+    { kind: "out", text: `${t.hero.name} — ${t.hero.kicker}` },
+    { kind: "prompt", cmd: "cat about.md" },
+    { kind: "out", text: t.hero.lead },
+    { kind: "prompt", cmd: "ls experience/" },
+    {
+      kind: "out",
+      text: t.exp.items.map((e, i) => `  ${String(i + 1).padStart(2, "0")}_${e.title.replace(/\s+/g, "_")}`).join("\n"),
+    },
+    { kind: "prompt", cmd: "head -n 1 research/papers.bib" },
+    {
+      kind: "out",
+      text: researchData.papers
+        .map((p) => `@article{${"title" in p ? p.title : p.titleEn}, year={${p.year}}, journal={${p.journal}}}`)
+        .join("\n"),
+    },
+    { kind: "prompt", cmd: "ls projects/" },
+    {
+      kind: "out",
+      text: t.projects.items.map((p) => `  ${p.title.toLowerCase().replace(/\s+/g, "-")}/`).join("\n"),
+    },
+    { kind: "prompt", cmd: "stack --tree" },
+    {
+      kind: "out",
+      text: stackData.map((s) => `${s.category}\n` + s.items.map((i) => `  ├─ ${i}`).join("\n")).join("\n"),
+    },
+  ];
+  return lines;
+}
+
+const PROMPT_PREFIX = "yasuaki@kyoto-u";
+
+export default function Terminal() {
+  const script = useMemo(() => buildScript(), []);
+  const [renderedLines, setRenderedLines] = useState<Line[]>([]);
+  const [typing, setTyping] = useState<{ idx: number; col: number } | null>({ idx: 0, col: 0 });
+  const [done, setDone] = useState(false);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!typing) return;
+    const line = script[typing.idx];
+    const targetText = line.kind === "prompt" ? line.cmd : line.text;
+    const speed = line.kind === "prompt" ? 55 : 8;
+    const pause = line.kind === "prompt" ? 320 : 120;
+
+    if (typing.col < targetText.length) {
+      const tm = setTimeout(() => setTyping({ idx: typing.idx, col: typing.col + 1 }), speed);
+      return () => clearTimeout(tm);
+    }
+
+    const tm = setTimeout(() => {
+      setRenderedLines((prev) => [...prev, line]);
+      const next = typing.idx + 1;
+      if (next >= script.length) {
+        setTyping(null);
+        setDone(true);
+      } else {
+        setTyping({ idx: next, col: 0 });
+      }
+    }, pause);
+    return () => clearTimeout(tm);
+  }, [typing, script]);
+
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
+  }, [renderedLines, typing]);
+
+  function renderLine(line: Line, key: number) {
+    if (line.kind === "prompt") {
+      return (
+        <div key={key} className="text-emerald-300">
+          <span className="text-amber-300">{PROMPT_PREFIX}</span>
+          <span className="text-slate-500">:</span>
+          <span className="text-sky-400">~</span>
+          <span className="text-slate-500">$ </span>
+          <span className="text-slate-100">{line.cmd}</span>
+        </div>
+      );
+    }
+    if (line.kind === "ascii") {
+      return (
+        <pre key={key} className="text-emerald-400/90 whitespace-pre">{line.text}</pre>
+      );
+    }
+    return (
+      <pre key={key} className="text-slate-300 whitespace-pre-wrap">{line.text}</pre>
+    );
+  }
+
+  function renderTyping() {
+    if (!typing) return null;
+    const line = script[typing.idx];
+    const text = line.kind === "prompt" ? line.cmd : line.text;
+    const visible = text.slice(0, typing.col);
+    if (line.kind === "prompt") {
+      return (
+        <div className="text-emerald-300">
+          <span className="text-amber-300">{PROMPT_PREFIX}</span>
+          <span className="text-slate-500">:</span>
+          <span className="text-sky-400">~</span>
+          <span className="text-slate-500">$ </span>
+          <span className="text-slate-100">{visible}</span>
+          <span className="ml-0.5 inline-block w-2 h-4 bg-emerald-300 align-middle animate-pulse" />
+        </div>
+      );
+    }
+    if (line.kind === "ascii") {
+      return <pre className="text-emerald-400/90 whitespace-pre">{visible}</pre>;
+    }
+    return <pre className="text-slate-300 whitespace-pre-wrap">{visible}</pre>;
+  }
+
+  return (
+    <div
+      ref={scrollRef}
+      className="font-mono text-sm bg-black/80 border border-emerald-500/30 rounded-lg shadow-[0_0_60px_rgba(16,185,129,0.08)] backdrop-blur-sm h-[70vh] md:h-[78vh] overflow-y-auto"
+    >
+      <div className="sticky top-0 flex items-center gap-2 bg-black/90 border-b border-emerald-500/20 px-3 py-2 text-xs text-slate-500">
+        <span className="w-3 h-3 rounded-full bg-red-500/80" />
+        <span className="w-3 h-3 rounded-full bg-amber-400/80" />
+        <span className="w-3 h-3 rounded-full bg-emerald-500/80" />
+        <span className="ml-2 text-slate-400">— {PROMPT_PREFIX}: ~/portfolio —</span>
+      </div>
+      <div className="p-5 space-y-1.5">
+        {renderedLines.map(renderLine)}
+        {renderTyping()}
+        {done && (
+          <div className="text-emerald-300 pt-2">
+            <span className="text-amber-300">{PROMPT_PREFIX}</span>
+            <span className="text-slate-500">:</span>
+            <span className="text-sky-400">~</span>
+            <span className="text-slate-500">$ </span>
+            <span className="ml-0.5 inline-block w-2 h-4 bg-emerald-300 align-middle animate-pulse" />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/variants/dashboard/BibtexButton.tsx
+++ b/components/variants/dashboard/BibtexButton.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useState } from "react";
+
+export default function BibtexButton({ bibtex }: { bibtex: string }) {
+  const [copied, setCopied] = useState(false);
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(bibtex);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1400);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={copy}
+      className="text-[10px] font-mono px-2 py-0.5 rounded border border-cyan-500/40 text-cyan-300 hover:bg-cyan-500/10 transition-colors"
+      aria-label="Copy BibTeX"
+    >
+      {copied ? "✓ copied" : "BibTeX"}
+    </button>
+  );
+}

--- a/components/variants/dashboard/Heatmap.tsx
+++ b/components/variants/dashboard/Heatmap.tsx
@@ -1,0 +1,77 @@
+// Synthetic-but-deterministic contribution heatmap based on a seed string.
+// (Public GitHub API doesn't expose contribution counts; the GraphQL endpoint
+// requires auth which we avoid in the static build.)
+function hash(seed: string, n: number) {
+  let h = 0;
+  for (let i = 0; i < seed.length; i++) h = (h * 31 + seed.charCodeAt(i)) >>> 0;
+  h = (h ^ n * 2654435761) >>> 0;
+  return h;
+}
+
+const LEVELS = [
+  "fill-white/5",
+  "fill-emerald-900/70",
+  "fill-emerald-700/80",
+  "fill-emerald-500/85",
+  "fill-emerald-300",
+];
+
+export default function Heatmap({ seed = "maruyamayasuaki" }: { seed?: string }) {
+  const weeks = 26;
+  const days = 7;
+  const cells: { x: number; y: number; level: number }[] = [];
+
+  for (let w = 0; w < weeks; w++) {
+    for (let d = 0; d < days; d++) {
+      const r = hash(seed, w * 7 + d) % 100;
+      let level = 0;
+      if (r > 92) level = 4;
+      else if (r > 80) level = 3;
+      else if (r > 60) level = 2;
+      else if (r > 35) level = 1;
+      cells.push({ x: w, y: d, level });
+    }
+  }
+
+  const cellSize = 12;
+  const gap = 3;
+  const totalActive = cells.filter((c) => c.level > 0).length;
+
+  return (
+    <div className="overflow-x-auto">
+      <svg
+        width={weeks * (cellSize + gap)}
+        height={days * (cellSize + gap) + 18}
+        className="block"
+      >
+        {cells.map((c, i) => (
+          <rect
+            key={i}
+            x={c.x * (cellSize + gap)}
+            y={c.y * (cellSize + gap)}
+            width={cellSize}
+            height={cellSize}
+            rx={2}
+            className={LEVELS[c.level]}
+          />
+        ))}
+        <text
+          x="0"
+          y={days * (cellSize + gap) + 14}
+          className="fill-slate-500 text-[10px]"
+        >
+          {totalActive} active days · last 26 weeks (illustrative)
+        </text>
+      </svg>
+      <div className="flex items-center gap-1 mt-2 text-[10px] text-slate-500">
+        Less
+        {LEVELS.map((c, i) => (
+          <svg key={i} width="10" height="10">
+            <rect width="10" height="10" rx={2} className={c} />
+          </svg>
+        ))}
+        More
+      </div>
+    </div>
+  );
+}

--- a/components/variants/dashboard/LangDonut.tsx
+++ b/components/variants/dashboard/LangDonut.tsx
@@ -1,0 +1,78 @@
+type Props = {
+  data: Record<string, number>;
+};
+
+const COLORS: Record<string, string> = {
+  Python: "#3776AB",
+  TypeScript: "#3178C6",
+  JavaScript: "#F7DF1E",
+  Ruby: "#CC342D",
+  Kotlin: "#A97BFF",
+  HTML: "#E34F26",
+  CSS: "#1572B6",
+  Shell: "#89E051",
+  Batchfile: "#C1F12E",
+  Java: "#B07219",
+  Go: "#00ADD8",
+  C: "#555555",
+  "C++": "#F34B7D",
+};
+
+function colorFor(name: string, i: number) {
+  if (COLORS[name]) return COLORS[name];
+  const palette = ["#06b6d4", "#a855f7", "#ec4899", "#f97316", "#84cc16", "#14b8a6"];
+  return palette[i % palette.length];
+}
+
+export default function LangDonut({ data }: Props) {
+  const entries = Object.entries(data);
+  const total = entries.reduce((s, [, v]) => s + v, 0) || 1;
+  const radius = 60;
+  const circ = 2 * Math.PI * radius;
+
+  let offset = 0;
+  const segments = entries.map(([name, value], i) => {
+    const frac = value / total;
+    const segLen = circ * frac;
+    const seg = (
+      <circle
+        key={name}
+        cx="80"
+        cy="80"
+        r={radius}
+        fill="transparent"
+        stroke={colorFor(name, i)}
+        strokeWidth="22"
+        strokeDasharray={`${segLen} ${circ - segLen}`}
+        strokeDashoffset={-offset}
+        transform="rotate(-90 80 80)"
+      />
+    );
+    offset += segLen;
+    return { name, frac, value, color: colorFor(name, i), seg };
+  });
+
+  return (
+    <div className="flex flex-col sm:flex-row gap-6 items-center">
+      <svg viewBox="0 0 160 160" className="w-40 h-40 flex-shrink-0">
+        <circle cx="80" cy="80" r={radius} fill="transparent" stroke="rgba(255,255,255,0.06)" strokeWidth="22" />
+        {segments.map((s) => s.seg)}
+        <text x="80" y="76" textAnchor="middle" className="fill-white text-xs font-semibold">
+          {entries.length}
+        </text>
+        <text x="80" y="92" textAnchor="middle" className="fill-slate-400 text-[10px]">
+          languages
+        </text>
+      </svg>
+      <ul className="text-xs space-y-1.5 w-full">
+        {segments.slice(0, 7).map((s) => (
+          <li key={s.name} className="flex items-center gap-2">
+            <span className="w-2.5 h-2.5 rounded-full" style={{ background: s.color }} />
+            <span className="text-slate-200 flex-1">{s.name}</span>
+            <span className="text-slate-500 tabular-nums">{(s.frac * 100).toFixed(1)}%</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/components/variants/dashboard/SkillRadar.tsx
+++ b/components/variants/dashboard/SkillRadar.tsx
@@ -1,0 +1,79 @@
+type Skill = { label: string; value: number };
+
+export default function SkillRadar({ skills }: { skills: Skill[] }) {
+  const size = 280;
+  const cx = size / 2;
+  const cy = size / 2;
+  const max = 100;
+  const radius = size / 2 - 36;
+  const n = skills.length;
+
+  function point(value: number, i: number) {
+    const angle = (i / n) * Math.PI * 2 - Math.PI / 2;
+    const r = (value / max) * radius;
+    return [cx + Math.cos(angle) * r, cy + Math.sin(angle) * r];
+  }
+
+  const polygon = skills.map((s, i) => point(s.value, i).join(",")).join(" ");
+
+  const rings = [25, 50, 75, 100];
+
+  return (
+    <svg viewBox={`0 0 ${size} ${size}`} className="w-full max-w-[320px] h-auto">
+      {rings.map((r) => {
+        const points = skills
+          .map((_, i) => point(r, i).join(","))
+          .join(" ");
+        return (
+          <polygon
+            key={r}
+            points={points}
+            fill="none"
+            stroke="rgba(255,255,255,0.07)"
+            strokeWidth="1"
+          />
+        );
+      })}
+      {skills.map((_, i) => {
+        const [x, y] = point(max, i);
+        return (
+          <line
+            key={i}
+            x1={cx}
+            y1={cy}
+            x2={x}
+            y2={y}
+            stroke="rgba(255,255,255,0.05)"
+          />
+        );
+      })}
+
+      <polygon
+        points={polygon}
+        fill="rgba(124,58,237,0.25)"
+        stroke="#7c3aed"
+        strokeWidth="1.5"
+      />
+      {skills.map((s, i) => {
+        const [x, y] = point(s.value, i);
+        return <circle key={s.label} cx={x} cy={y} r="3" fill="#a5f3fc" />;
+      })}
+
+      {skills.map((s, i) => {
+        const [x, y] = point(max + 12, i);
+        return (
+          <text
+            key={s.label}
+            x={x}
+            y={y}
+            textAnchor="middle"
+            dominantBaseline="middle"
+            className="fill-slate-300 text-[10px]"
+          >
+            {s.label}
+          </text>
+        );
+      })}
+    </svg>
+  );
+}

--- a/components/variants/ide/IdeShell.tsx
+++ b/components/variants/ide/IdeShell.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useState } from "react";
+
+export type IdeFile = {
+  id: string;
+  label: string;
+  icon: string;
+  iconColor: string;
+  language: string;
+  highlighted: string;
+  raw: string;
+};
+
+export default function IdeShell({ files }: { files: IdeFile[] }) {
+  const [activeId, setActiveId] = useState(files[0].id);
+  const [openTabs, setOpenTabs] = useState<string[]>([files[0].id]);
+  const [explorerOpen, setExplorerOpen] = useState(true);
+
+  const active = files.find((f) => f.id === activeId)!;
+  const lineCount = active.raw.split("\n").length;
+
+  function open(id: string) {
+    setActiveId(id);
+    setOpenTabs((prev) => (prev.includes(id) ? prev : [...prev, id]));
+  }
+  function close(id: string) {
+    setOpenTabs((prev) => {
+      const next = prev.filter((t) => t !== id);
+      if (next.length === 0) return [files[0].id];
+      if (id === activeId) setActiveId(next[next.length - 1]);
+      return next;
+    });
+  }
+
+  return (
+    <div className="rounded-lg overflow-hidden border border-white/10 bg-[#1e1e1e] text-slate-200 font-mono text-[13px] flex flex-col h-[80vh] shadow-2xl shadow-black/40">
+      {/* Title bar */}
+      <div className="flex items-center justify-between px-3 py-1.5 bg-[#3c3c3c] border-b border-black/40">
+        <div className="flex items-center gap-1.5">
+          <span className="w-3 h-3 rounded-full bg-red-500" />
+          <span className="w-3 h-3 rounded-full bg-amber-400" />
+          <span className="w-3 h-3 rounded-full bg-emerald-500" />
+        </div>
+        <div className="text-xs text-slate-300">portfolio — Visual Studio Code</div>
+        <button
+          className="md:hidden text-xs text-slate-400 hover:text-white"
+          onClick={() => setExplorerOpen((v) => !v)}
+        >
+          {explorerOpen ? "Hide" : "Show"} Explorer
+        </button>
+      </div>
+
+      <div className="flex flex-1 min-h-0">
+        {/* Activity bar */}
+        <div className="hidden sm:flex w-12 bg-[#333333] border-r border-black/40 flex-col items-center py-3 gap-4 text-slate-400 text-lg">
+          <span title="Explorer" className="text-white">▤</span>
+          <span title="Search">⌕</span>
+          <span title="Source Control">⑂</span>
+          <span title="Run">▷</span>
+          <span title="Extensions">▦</span>
+        </div>
+
+        {/* Explorer */}
+        {explorerOpen && (
+          <aside className="w-56 bg-[#252526] border-r border-black/40 text-[12px] py-2 flex-shrink-0 overflow-y-auto">
+            <div className="px-3 py-1 text-[10px] uppercase tracking-wider text-slate-400">Explorer</div>
+            <div className="px-3 py-0.5 text-slate-200 font-semibold">▾ PORTFOLIO</div>
+            <ul className="text-slate-300">
+              {files.map((f) => (
+                <li key={f.id}>
+                  <button
+                    onClick={() => open(f.id)}
+                    className={`w-full text-left flex items-center gap-1.5 px-6 py-1 hover:bg-white/5 ${
+                      activeId === f.id ? "bg-white/10 text-white" : ""
+                    }`}
+                  >
+                    <span className={f.iconColor}>{f.icon}</span>
+                    <span>{f.label}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </aside>
+        )}
+
+        {/* Editor area */}
+        <div className="flex-1 flex flex-col min-w-0 bg-[#1e1e1e]">
+          {/* Tabs */}
+          <div className="flex bg-[#2d2d2d] border-b border-black/40 overflow-x-auto">
+            {openTabs.map((id) => {
+              const f = files.find((x) => x.id === id)!;
+              const isActive = id === activeId;
+              return (
+                <div
+                  key={id}
+                  className={`flex items-center gap-2 px-3 py-1.5 text-xs border-r border-black/40 cursor-pointer min-w-fit ${
+                    isActive ? "bg-[#1e1e1e] text-white" : "text-slate-400 hover:bg-white/5"
+                  }`}
+                  onClick={() => setActiveId(id)}
+                >
+                  <span className={f.iconColor}>{f.icon}</span>
+                  <span className="whitespace-nowrap">{f.label}</span>
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      close(id);
+                    }}
+                    className="ml-1 text-slate-500 hover:text-white"
+                    aria-label={`Close ${f.label}`}
+                  >
+                    ×
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+
+          {/* Editor */}
+          <div className="flex-1 overflow-auto">
+            <div
+              className="ide-shiki text-[13px] leading-6"
+              dangerouslySetInnerHTML={{ __html: active.highlighted }}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Status bar */}
+      <div className="flex items-center justify-between px-3 py-1 bg-[#007acc] text-white text-[11px] font-sans">
+        <div className="flex items-center gap-3">
+          <span>⑂ claude/review-implementation-design-xYJpv</span>
+          <span className="opacity-80">↻ 0 ↑ 0</span>
+          <span className="opacity-80">⚠ 0  ⓧ 0</span>
+        </div>
+        <div className="flex items-center gap-3">
+          <span>Ln 1, Col 1</span>
+          <span>Spaces: 2</span>
+          <span>UTF-8</span>
+          <span>{active.language}</span>
+          <span>{lineCount} L</span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/variants/ide/ide.css
+++ b/components/variants/ide/ide.css
@@ -1,0 +1,33 @@
+/* Force Shiki output to fill the editor area */
+.ide-shiki pre {
+  margin: 0;
+  padding: 1rem 1rem 1rem 0;
+  background: transparent !important;
+  min-height: 100%;
+  font-family: var(--font-geist-mono), ui-monospace, monospace;
+}
+.ide-shiki pre code {
+  display: block;
+  counter-reset: line;
+  padding-right: 1rem;
+}
+.ide-shiki .line {
+  display: block;
+  position: relative;
+  padding-left: 4rem;
+  min-height: 1.5em;
+}
+.ide-shiki .line::before {
+  counter-increment: line;
+  content: counter(line);
+  position: absolute;
+  left: 0;
+  width: 3rem;
+  text-align: right;
+  color: rgba(133, 153, 184, 0.45);
+  user-select: none;
+  font-size: 0.8em;
+}
+.ide-shiki .line:hover {
+  background: rgba(255, 255, 255, 0.03);
+}

--- a/components/variants/mi-lab/BayesOpt1D.tsx
+++ b/components/variants/mi-lab/BayesOpt1D.tsx
@@ -1,0 +1,271 @@
+"use client";
+
+// 1-D Bayesian Optimization mini-demo.
+// True f is hidden (a smooth bumpy function on [0,1]); we sample, fit a tiny GP
+// (RBF kernel), and show mean ± 2σ band plus the EI acquisition function.
+// User clicks "Sample next" to add the argmax of EI; or clicks the panel to add
+// a manual sample.
+
+import { useMemo, useState } from "react";
+
+const W = 600;
+const H = 280;
+const padL = 36;
+const padR = 16;
+const padT = 16;
+const padB = 28;
+const innerW = W - padL - padR;
+const innerH = H - padT - padB;
+
+// Hidden ground-truth: a strain-property-like nonlinear curve.
+function f(x: number) {
+  return Math.sin(6 * x) * (1 - x) * 0.6 + 0.5 + 0.18 * Math.cos(12 * x) * x;
+}
+
+// RBF kernel
+function k(a: number, b: number, ls = 0.08, sigF = 0.3) {
+  return sigF * sigF * Math.exp(-((a - b) ** 2) / (2 * ls * ls));
+}
+
+// Tiny GP with explicit matrix ops; works fine for N ~ 30
+function gp(xs: number[], ys: number[], grid: number[]) {
+  const n = xs.length;
+  const noise = 0.0008;
+  const K: number[][] = Array.from({ length: n }, (_, i) =>
+    Array.from({ length: n }, (_, j) => k(xs[i], xs[j]) + (i === j ? noise : 0)),
+  );
+
+  // Solve K alpha = y via Cholesky
+  const L: number[][] = Array.from({ length: n }, () => Array(n).fill(0));
+  for (let i = 0; i < n; i++) {
+    for (let j = 0; j <= i; j++) {
+      let s = K[i][j];
+      for (let p = 0; p < j; p++) s -= L[i][p] * L[j][p];
+      if (i === j) {
+        L[i][j] = Math.sqrt(Math.max(s, 1e-9));
+      } else {
+        L[i][j] = s / L[j][j];
+      }
+    }
+  }
+  // Solve L z = y, then L^T alpha = z
+  const z = Array(n).fill(0);
+  for (let i = 0; i < n; i++) {
+    let s = ys[i];
+    for (let p = 0; p < i; p++) s -= L[i][p] * z[p];
+    z[i] = s / L[i][i];
+  }
+  const alpha = Array(n).fill(0);
+  for (let i = n - 1; i >= 0; i--) {
+    let s = z[i];
+    for (let p = i + 1; p < n; p++) s -= L[p][i] * alpha[p];
+    alpha[i] = s / L[i][i];
+  }
+
+  return grid.map((xstar) => {
+    const ks = xs.map((xi) => k(xi, xstar));
+    let mean = 0;
+    for (let i = 0; i < n; i++) mean += ks[i] * alpha[i];
+
+    // Solve L v = ks
+    const v = Array(n).fill(0);
+    for (let i = 0; i < n; i++) {
+      let s = ks[i];
+      for (let p = 0; p < i; p++) s -= L[i][p] * v[p];
+      v[i] = s / L[i][i];
+    }
+    let varStar = k(xstar, xstar);
+    for (let i = 0; i < n; i++) varStar -= v[i] * v[i];
+    return { mean, std: Math.sqrt(Math.max(varStar, 1e-6)) };
+  });
+}
+
+// Expected Improvement
+function ei(mean: number, std: number, fbest: number) {
+  if (std < 1e-6) return 0;
+  const z = (mean - fbest) / std;
+  const pdf = Math.exp(-0.5 * z * z) / Math.sqrt(2 * Math.PI);
+  // CDF approx
+  const cdf = 0.5 * (1 + erf(z / Math.SQRT2));
+  return (mean - fbest) * cdf + std * pdf;
+}
+function erf(x: number) {
+  const sign = x < 0 ? -1 : 1;
+  const ax = Math.abs(x);
+  const t = 1 / (1 + 0.3275911 * ax);
+  const y =
+    1 -
+    ((((1.061405429 * t - 1.453152027) * t + 1.421413741) * t - 0.284496736) * t + 0.254829592) *
+      t *
+      Math.exp(-ax * ax);
+  return sign * y;
+}
+
+const initialSamples = [0.05, 0.32, 0.78];
+
+function fmt(n: number) {
+  return n.toFixed(3);
+}
+
+export default function BayesOpt1D() {
+  const [xs, setXs] = useState<number[]>(initialSamples);
+  const ys = useMemo(() => xs.map(f), [xs]);
+
+  const grid = useMemo(() => Array.from({ length: 121 }, (_, i) => i / 120), []);
+  const post = useMemo(() => gp(xs, ys, grid), [xs, ys, grid]);
+
+  const fbest = Math.max(...ys);
+  const eis = post.map((p) => ei(p.mean, p.std, fbest));
+  const eiMax = Math.max(...eis, 1e-6);
+  const argmaxIdx = eis.indexOf(eiMax);
+  const xNext = grid[argmaxIdx];
+
+  function px(x: number) {
+    return padL + x * innerW;
+  }
+  function py(y: number) {
+    // map y∈[0,1] → top→bottom
+    return padT + (1 - Math.max(0, Math.min(1, y))) * innerH;
+  }
+
+  const meanPath = grid.map((x, i) => `${i === 0 ? "M" : "L"}${px(x)},${py(post[i].mean)}`).join(" ");
+  const upperPath = grid.map((x, i) => `${i === 0 ? "M" : "L"}${px(x)},${py(post[i].mean + 2 * post[i].std)}`).join(" ");
+  const lowerPath = grid
+    .slice()
+    .reverse()
+    .map((x, i) => {
+      const orig = grid.length - 1 - i;
+      return `L${px(x)},${py(post[orig].mean - 2 * post[orig].std)}`;
+    })
+    .join(" ");
+  const bandPath = upperPath + " " + lowerPath + " Z";
+
+  // EI as a normalized curve in its own band (bottom 22%)
+  const eiBandTop = padT + innerH * 0.78;
+  const eiBandBottom = padT + innerH;
+  function eiY(v: number) {
+    const f = v / eiMax;
+    return eiBandBottom - f * (eiBandBottom - eiBandTop);
+  }
+  const eiPath = grid.map((x, i) => `${i === 0 ? "M" : "L"}${px(x)},${eiY(eis[i])}`).join(" ");
+
+  function addSample(x: number) {
+    setXs((prev) => [...prev, x].sort((a, b) => a - b));
+  }
+  function reset() {
+    setXs(initialSamples);
+  }
+
+  function handleClick(e: React.MouseEvent<SVGSVGElement>) {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const px2 = ((e.clientX - rect.left) / rect.width) * W;
+    const xn = Math.max(0, Math.min(1, (px2 - padL) / innerW));
+    addSample(xn);
+  }
+
+  return (
+    <div className="rounded-xl border border-cyan-500/20 bg-black/40 backdrop-blur p-5">
+      <div className="flex flex-wrap items-baseline gap-3 mb-3">
+        <h3 className="text-cyan-300 font-semibold text-sm">
+          Bayesian Optimization · 1D demo
+        </h3>
+        <p className="text-xs text-slate-400 flex-1 min-w-[12ch]">
+          GP posterior (mean ± 2σ) と EI 獲得関数。次の探索点 <span className="text-cyan-300">x*</span> = {fmt(xNext)} (EI = {fmt(eiMax)})。
+        </p>
+        <button
+          onClick={() => addSample(xNext)}
+          className="text-xs px-3 py-1 rounded-md bg-cyan-500/20 text-cyan-200 border border-cyan-400/40 hover:bg-cyan-500/30"
+        >
+          Sample x*
+        </button>
+        <button
+          onClick={reset}
+          className="text-xs px-3 py-1 rounded-md bg-white/5 text-slate-300 border border-white/10 hover:bg-white/10"
+        >
+          Reset
+        </button>
+      </div>
+
+      <svg
+        viewBox={`0 0 ${W} ${H}`}
+        className="w-full h-auto cursor-crosshair"
+        onClick={handleClick}
+        role="img"
+        aria-label="Bayesian Optimization GP posterior and EI acquisition demo"
+      >
+        {/* axes */}
+        <line x1={padL} y1={padT} x2={padL} y2={padT + innerH} stroke="rgba(255,255,255,0.18)" />
+        <line x1={padL} y1={padT + innerH} x2={padL + innerW} y2={padT + innerH} stroke="rgba(255,255,255,0.18)" />
+
+        {/* uncertainty band */}
+        <path d={bandPath} fill="rgba(124,58,237,0.18)" />
+
+        {/* true function (faint, dashed) */}
+        <path
+          d={grid.map((x, i) => `${i === 0 ? "M" : "L"}${px(x)},${py(f(x))}`).join(" ")}
+          fill="none"
+          stroke="rgba(255,255,255,0.18)"
+          strokeDasharray="4 4"
+          strokeWidth="1"
+        />
+
+        {/* posterior mean */}
+        <path d={meanPath} fill="none" stroke="#a5f3fc" strokeWidth="1.6" />
+
+        {/* observations */}
+        {xs.map((x, i) => (
+          <g key={i}>
+            <line
+              x1={px(x)}
+              y1={py(ys[i])}
+              x2={px(x)}
+              y2={padT + innerH}
+              stroke="rgba(245,158,11,0.45)"
+              strokeWidth="1"
+            />
+            <circle cx={px(x)} cy={py(ys[i])} r="4" fill="#fbbf24" stroke="#fff" strokeWidth="1" />
+          </g>
+        ))}
+
+        {/* EI band separator */}
+        <line
+          x1={padL}
+          y1={eiBandTop}
+          x2={padL + innerW}
+          y2={eiBandTop}
+          stroke="rgba(255,255,255,0.08)"
+          strokeDasharray="2 4"
+        />
+        <text x={padL + 4} y={eiBandTop + 12} className="fill-slate-500 text-[9px]">
+          EI(x)
+        </text>
+
+        {/* EI curve */}
+        <path d={eiPath} fill="none" stroke="#22d3ee" strokeWidth="1.4" />
+        <line
+          x1={px(xNext)}
+          y1={padT}
+          x2={px(xNext)}
+          y2={padT + innerH}
+          stroke="#22d3ee"
+          strokeDasharray="2 3"
+          strokeWidth="1"
+        />
+
+        <text x={padL - 6} y={py(0)} textAnchor="end" className="fill-slate-500 text-[9px]">
+          0
+        </text>
+        <text x={padL - 6} y={py(1) + 4} textAnchor="end" className="fill-slate-500 text-[9px]">
+          1
+        </text>
+        <text x={padL + innerW} y={padT + innerH + 16} textAnchor="end" className="fill-slate-500 text-[9px]">
+          strain →
+        </text>
+      </svg>
+
+      <p className="text-[10px] text-slate-500 mt-2">
+        パネルをクリックして任意の x で観測を追加できます。{xs.length} 観測。最良値 f<sub>best</sub> = {fmt(fbest)}。
+      </p>
+    </div>
+  );
+}

--- a/components/variants/mi-lab/Lattice3D.tsx
+++ b/components/variants/mi-lab/Lattice3D.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { Canvas, useFrame } from "@react-three/fiber";
+import { OrbitControls } from "@react-three/drei";
+import { useMemo, useRef } from "react";
+import * as THREE from "three";
+
+// Perovskite-like ABO3 lattice (PbTiO3 schematic — relevant to Maruyama-san's
+// research on ferroelectric strain engineering).
+function buildAtoms() {
+  const a = 1; // lattice param (visual)
+  const N = 2; // 2x2x2 supercell visualization
+  const atoms: { pos: [number, number, number]; type: "A" | "B" | "O" }[] = [];
+
+  for (let i = -N; i <= N; i++) {
+    for (let j = -N; j <= N; j++) {
+      for (let k = -N; k <= N; k++) {
+        // A-site (corners): Pb-like — large, warm color
+        atoms.push({ pos: [i * a, j * a, k * a], type: "A" });
+      }
+    }
+  }
+  // B-site (body center) and O (face centers) per cell
+  for (let i = -N; i <= N - 1; i++) {
+    for (let j = -N; j <= N - 1; j++) {
+      for (let k = -N; k <= N - 1; k++) {
+        const cx = i + 0.5;
+        const cy = j + 0.5;
+        const cz = k + 0.5;
+        atoms.push({ pos: [cx, cy, cz], type: "B" });
+        atoms.push({ pos: [cx, cy, k], type: "O" });
+        atoms.push({ pos: [cx, cy, k + 1], type: "O" });
+        atoms.push({ pos: [cx, j, cz], type: "O" });
+        atoms.push({ pos: [cx, j + 1, cz], type: "O" });
+        atoms.push({ pos: [i, cy, cz], type: "O" });
+        atoms.push({ pos: [i + 1, cy, cz], type: "O" });
+      }
+    }
+  }
+  return atoms;
+}
+
+const COLOR: Record<"A" | "B" | "O", string> = {
+  A: "#fbbf24", // amber
+  B: "#22d3ee", // cyan
+  O: "#ef4444", // red
+};
+const RADIUS: Record<"A" | "B" | "O", number> = {
+  A: 0.16,
+  B: 0.13,
+  O: 0.08,
+};
+
+function Atoms() {
+  const ref = useRef<THREE.Group>(null);
+  useFrame((_, dt) => {
+    if (ref.current) ref.current.rotation.y += dt * 0.15;
+  });
+
+  const atoms = useMemo(() => buildAtoms(), []);
+
+  // Use instanced mesh per atom type for perf
+  const groups = (["A", "B", "O"] as const).map((type) => {
+    const sel = atoms.filter((x) => x.type === type);
+    return { type, items: sel };
+  });
+
+  return (
+    <group ref={ref}>
+      {/* atoms */}
+      {groups.map((g) => (
+        <group key={g.type}>
+          {g.items.map((a, i) => (
+            <mesh key={`${g.type}-${i}`} position={a.pos}>
+              <sphereGeometry args={[RADIUS[g.type], 16, 16]} />
+              <meshStandardMaterial color={COLOR[g.type]} roughness={0.35} metalness={0.1} />
+            </mesh>
+          ))}
+        </group>
+      ))}
+
+      {/* bonds: connect each B to its 6 nearest O */}
+      {atoms
+        .filter((a) => a.type === "B")
+        .flatMap((b, bi) => {
+          const neighbors = atoms
+            .filter((o) => o.type === "O")
+            .map((o) => {
+              const d = Math.hypot(o.pos[0] - b.pos[0], o.pos[1] - b.pos[1], o.pos[2] - b.pos[2]);
+              return { o, d };
+            })
+            .filter((x) => x.d < 0.6 && x.d > 0.01)
+            .slice(0, 6);
+          return neighbors.map((n, ni) => {
+            const start = new THREE.Vector3(...b.pos);
+            const end = new THREE.Vector3(...n.o.pos);
+            const mid = start.clone().add(end).multiplyScalar(0.5);
+            const dir = end.clone().sub(start);
+            const length = dir.length();
+            const quaternion = new THREE.Quaternion().setFromUnitVectors(
+              new THREE.Vector3(0, 1, 0),
+              dir.clone().normalize(),
+            );
+            return (
+              <mesh
+                key={`b-${bi}-${ni}`}
+                position={mid.toArray()}
+                quaternion={quaternion}
+              >
+                <cylinderGeometry args={[0.012, 0.012, length, 6]} />
+                <meshBasicMaterial color="#94a3b8" transparent opacity={0.45} />
+              </mesh>
+            );
+          });
+        })}
+    </group>
+  );
+}
+
+export default function Lattice3D() {
+  return (
+    <div className="absolute inset-0">
+      <Canvas
+        dpr={[1, 1.5]}
+        camera={{ position: [3.4, 2.4, 3.4], fov: 50 }}
+        gl={{ antialias: true, alpha: true }}
+      >
+        <ambientLight intensity={0.4} />
+        <directionalLight position={[5, 5, 5]} intensity={1.0} />
+        <pointLight position={[-3, -2, -3]} intensity={0.6} color="#7c3aed" />
+        <Atoms />
+        <OrbitControls
+          enablePan={false}
+          enableZoom
+          minDistance={2.5}
+          maxDistance={8}
+          autoRotate={false}
+        />
+      </Canvas>
+    </div>
+  );
+}

--- a/lib/github-stats.json
+++ b/lib/github-stats.json
@@ -1,0 +1,107 @@
+{
+  "generatedAt": "2026-04-26T04:25:24.216Z",
+  "user": {
+    "login": "maruyamayasuaki",
+    "name": "marky",
+    "bio": null,
+    "publicRepos": 17,
+    "followers": 1,
+    "following": 5,
+    "avatarUrl": "https://avatars.githubusercontent.com/u/143987589?v=4",
+    "htmlUrl": "https://github.com/maruyamayasuaki"
+  },
+  "totals": {
+    "stars": 7,
+    "repos": 9
+  },
+  "languages": {
+    "Jupyter Notebook": 543156,
+    "Kotlin": 42173,
+    "TypeScript": 34101,
+    "Python": 13216,
+    "CSS": 1582,
+    "JavaScript": 559
+  },
+  "featured": [
+    {
+      "name": "maruyamayasuaki.github.io",
+      "description": null,
+      "url": "https://github.com/maruyamayasuaki/maruyamayasuaki.github.io",
+      "stars": 1,
+      "forks": 0,
+      "language": "TypeScript",
+      "updated": "2026-04-26T02:49:40Z",
+      "topics": []
+    },
+    {
+      "name": "maruyamayasuaki",
+      "description": null,
+      "url": "https://github.com/maruyamayasuaki/maruyamayasuaki",
+      "stars": 1,
+      "forks": 0,
+      "language": null,
+      "updated": "2026-04-10T05:09:08Z",
+      "topics": []
+    },
+    {
+      "name": "TimerBlockSNS-chrome_ex",
+      "description": null,
+      "url": "https://github.com/maruyamayasuaki/TimerBlockSNS-chrome_ex",
+      "stars": 1,
+      "forks": 0,
+      "language": "JavaScript",
+      "updated": "2025-06-30T00:52:27Z",
+      "topics": []
+    },
+    {
+      "name": "Local_Food_Discovery",
+      "description": null,
+      "url": "https://github.com/maruyamayasuaki/Local_Food_Discovery",
+      "stars": 1,
+      "forks": 0,
+      "language": "Ruby",
+      "updated": "2025-06-29T14:12:37Z",
+      "topics": []
+    },
+    {
+      "name": "Starbucks_map_app",
+      "description": null,
+      "url": "https://github.com/maruyamayasuaki/Starbucks_map_app",
+      "stars": 1,
+      "forks": 0,
+      "language": "Kotlin",
+      "updated": "2026-04-02T05:57:15Z",
+      "topics": []
+    },
+    {
+      "name": "Todo_app",
+      "description": null,
+      "url": "https://github.com/maruyamayasuaki/Todo_app",
+      "stars": 1,
+      "forks": 0,
+      "language": "Kotlin",
+      "updated": "2025-06-09T08:07:04Z",
+      "topics": []
+    },
+    {
+      "name": "Electricity-Transformer-Temperature",
+      "description": null,
+      "url": "https://github.com/maruyamayasuaki/Electricity-Transformer-Temperature",
+      "stars": 1,
+      "forks": 0,
+      "language": "Jupyter Notebook",
+      "updated": "2024-09-13T10:39:19Z",
+      "topics": []
+    },
+    {
+      "name": "Bus_time_management",
+      "description": null,
+      "url": "https://github.com/maruyamayasuaki/Bus_time_management",
+      "stars": 0,
+      "forks": 0,
+      "language": "Python",
+      "updated": "2026-04-07T02:59:53Z",
+      "topics": []
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,16 +8,21 @@
       "name": "maruyamayasuaki.github.io",
       "version": "0.1.0",
       "dependencies": {
+        "@react-three/drei": "^10.7.7",
+        "@react-three/fiber": "^9.6.0",
         "framer-motion": "^12.38.0",
         "next": "16.2.4",
         "react": "19.2.4",
-        "react-dom": "19.2.4"
+        "react-dom": "19.2.4",
+        "shiki": "^4.0.2",
+        "three": "^0.184.0"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/three": "^0.184.0",
         "eslint": "^9",
         "eslint-config-next": "16.2.4",
         "tailwindcss": "^4",
@@ -229,6 +234,15 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -276,6 +290,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "license": "Apache-2.0"
     },
     "node_modules/@emnapi/core": {
       "version": "1.10.0",
@@ -1036,6 +1056,24 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mediapipe/tasks-vision": {
+      "version": "0.10.17",
+      "resolved": "https://registry.npmjs.org/@mediapipe/tasks-vision/-/tasks-vision-0.10.17.tgz",
+      "integrity": "sha512-CZWV/q6TTe8ta61cZXjfnnHsfWIdFhms03M9T7Cnd5y2mdpylJM0rF1qRq+wsQVRMLz1OYPVEBU9ph2Bx8cxrg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@monogrid/gainmap-js": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@monogrid/gainmap-js/-/gainmap-js-3.4.0.tgz",
+      "integrity": "sha512-2Z0FATFHaoYJ8b+Y4y4Hgfn3FRFwuU5zRrk+9dFWp4uGAdHGqVEdP7HP+gLA3X469KXHmfupJaUbKo1b/aDKIg==",
+      "license": "MIT",
+      "dependencies": {
+        "promise-worker-transferable": "^1.0.4"
+      },
+      "peerDependencies": {
+        "three": ">= 0.159.0"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -1241,11 +1279,199 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@react-three/drei": {
+      "version": "10.7.7",
+      "resolved": "https://registry.npmjs.org/@react-three/drei/-/drei-10.7.7.tgz",
+      "integrity": "sha512-ff+J5iloR0k4tC++QtD/j9u3w5fzfgFAWDtAGQah9pF2B1YgOq/5JxqY0/aVoQG5r3xSZz0cv5tk2YuBob4xEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.26.0",
+        "@mediapipe/tasks-vision": "0.10.17",
+        "@monogrid/gainmap-js": "^3.0.6",
+        "@use-gesture/react": "^10.3.1",
+        "camera-controls": "^3.1.0",
+        "cross-env": "^7.0.3",
+        "detect-gpu": "^5.0.56",
+        "glsl-noise": "^0.0.0",
+        "hls.js": "^1.5.17",
+        "maath": "^0.10.8",
+        "meshline": "^3.3.1",
+        "stats-gl": "^2.2.8",
+        "stats.js": "^0.17.0",
+        "suspend-react": "^0.1.3",
+        "three-mesh-bvh": "^0.8.3",
+        "three-stdlib": "^2.35.6",
+        "troika-three-text": "^0.52.4",
+        "tunnel-rat": "^0.1.2",
+        "use-sync-external-store": "^1.4.0",
+        "utility-types": "^3.11.0",
+        "zustand": "^5.0.1"
+      },
+      "peerDependencies": {
+        "@react-three/fiber": "^9.0.0",
+        "react": "^19",
+        "react-dom": "^19",
+        "three": ">=0.159"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-9.6.0.tgz",
+      "integrity": "sha512-90abYK2q5/qDM+GACs9zRvc5KhEEpEWqWlHSd64zTPNxg+9wCJvTfyD9x2so7hlQhjRYO1Fa6flR3BC/kpTFkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@types/webxr": "*",
+        "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
+        "its-fine": "^2.0.0",
+        "react-use-measure": "^2.1.7",
+        "scheduler": "^0.27.0",
+        "suspend-react": "^0.1.3",
+        "use-sync-external-store": "^1.4.0",
+        "zustand": "^5.0.3"
+      },
+      "peerDependencies": {
+        "expo": ">=43.0",
+        "expo-asset": ">=8.4",
+        "expo-file-system": ">=11.0",
+        "expo-gl": ">=11.0",
+        "react": ">=19 <19.3",
+        "react-dom": ">=19 <19.3",
+        "react-native": ">=0.78",
+        "three": ">=0.156"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-asset": {
+          "optional": true
+        },
+        "expo-file-system": {
+          "optional": true
+        },
+        "expo-gl": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@shikijs/core": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.0.2.tgz",
+      "integrity": "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.0.2",
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.0.2.tgz",
+      "integrity": "sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.0.2.tgz",
+      "integrity": "sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.0.2.tgz",
+      "integrity": "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.0.2.tgz",
+      "integrity": "sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.0.2.tgz",
+      "integrity": "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
+      "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "license": "MIT"
     },
     "node_modules/@swc/helpers": {
@@ -1528,6 +1754,12 @@
         "tailwindcss": "4.2.4"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "license": "MIT"
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1539,12 +1771,27 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/draco3d": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@types/draco3d/-/draco3d-1.4.10.tgz",
+      "integrity": "sha512-AX22jp8Y7wwaBgAixaSvkoG4M/+PlAcm3Qs4OW8yT9DM4xUpWKeFhLueTAyZF39pviAdcDdeJoACapiAceqNcw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -1560,6 +1807,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "20.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
@@ -1570,11 +1826,16 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/offscreencanvas": {
+      "version": "2019.7.3",
+      "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.3.tgz",
+      "integrity": "sha512-ieXiYmgSRXUDeOntE1InxjWyvEelZGP63M+cGuquuRLuIKKT1osnkXjxev9B7d1nXSug5vpunx+gNlbVxMlC9A==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1589,6 +1850,47 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.184.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.184.0.tgz",
+      "integrity": "sha512-4mY2tZAu0y0B0567w7013BBXSpsP0+Z48NJvmNo4Y/Pf76yCyz6Jw4P3tUVs10WuYNXXZ+wmHyGWpCek3amJxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.1.1"
+      }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.59.0",
@@ -1885,6 +2187,12 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC"
+    },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
@@ -2153,6 +2461,24 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@use-gesture/core": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/core/-/core-10.3.1.tgz",
+      "integrity": "sha512-WcINiDt8WjqBdUXye25anHiNxPc0VOrlT8F6LLkU6cycrOGUDyY/yyFmsg3k8i5OLvv25llc0QC45GhR/C8llw==",
+      "license": "MIT"
+    },
+    "node_modules/@use-gesture/react": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/@use-gesture/react/-/react-10.3.1.tgz",
+      "integrity": "sha512-Yy19y6O2GJq8f7CHf7L0nxL8bf4PZCPaVOCgJrusOeFHY1LvHgYXnmnXg6N5iwAnbgbZCDjo60SiM6IPJi9C5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@use-gesture/core": "10.3.1"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0"
+      }
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -2447,6 +2773,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.22",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.22.tgz",
@@ -2457,6 +2803,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -2515,6 +2870,30 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/call-bind": {
@@ -2577,6 +2956,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/camera-controls": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/camera-controls/-/camera-controls-3.1.2.tgz",
+      "integrity": "sha512-xkxfpG2ECZ6Ww5/9+kf4mfg1VEYAoe9aDSY+IwF0UEs7qEzwy0aVRfs2grImIECs/PoBtWFrh7RXsQkwG922JA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.0.0",
+        "npm": ">=10.5.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.126.1"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001790",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001790.tgz",
@@ -2597,6 +2989,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2612,6 +3014,26 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/client-only": {
@@ -2640,6 +3062,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -2654,11 +3086,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -2673,7 +3122,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -2798,6 +3246,24 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-gpu": {
+      "version": "5.0.70",
+      "resolved": "https://registry.npmjs.org/detect-gpu/-/detect-gpu-5.0.70.tgz",
+      "integrity": "sha512-bqerEP1Ese6nt3rFkwPnGbsUF9a4q+gMmpTVVOEzoCyeCc+y7/RvJnQZJx1JwhgQI5Ntg0Kgat8Uu7XpBqnz1w==",
+      "license": "MIT",
+      "dependencies": {
+        "webgl-constants": "^1.1.1"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2806,6 +3272,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/doctrine": {
@@ -2820,6 +3299,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/draco3d": {
+      "version": "1.5.7",
+      "resolved": "https://registry.npmjs.org/draco3d/-/draco3d-1.5.7.tgz",
+      "integrity": "sha512-m6WCKt/erDXcw+70IJXnG7M3awwQPAsZvJGX5zY7beBqpELw6RDGkYVU0W43AFxye4pDZ5i2Lbyc/NNGqwjUVQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3531,6 +4016,12 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -3812,6 +4303,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/glsl-noise": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-noise/-/glsl-noise-0.0.0.tgz",
+      "integrity": "sha512-b/ZCF6amfAUb7dJM/MxRs7AetQEahYzJ8PtgfrmEdtw6uyGOr+ZSGtgjFm6mfsBkxJ4d2W7kg+Nlqzqvn3Bc0w==",
+      "license": "MIT"
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -3926,6 +4423,42 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -3943,6 +4476,42 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/hls.js": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.16.tgz",
+      "integrity": "sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3952,6 +4521,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -4265,6 +4840,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-promise": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+      "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -4421,7 +5002,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/iterator.prototype": {
@@ -4440,6 +5020,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/its-fine": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-2.0.0.tgz",
+      "integrity": "sha512-KLViCmWx94zOvpLwSlsx6yOCeMhZYaxrJV87Po5k/FoZzcPSahvK5qJ7fYhS61sZi5ikmh2S3Hz55A2l3U69ng==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.9"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
       }
     },
     "node_modules/jiti": {
@@ -4577,6 +5169,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -4886,6 +5487,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/maath": {
+      "version": "0.10.8",
+      "resolved": "https://registry.npmjs.org/maath/-/maath-0.10.8.tgz",
+      "integrity": "sha512-tRvbDF0Pgqz+9XUa4jjfgAQ8/aPKmQdWXilFu2tMy4GWj4NOsx99HlULO4IeREfbO3a0sA145DZYyvXPkybm0g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/three": ">=0.134.0",
+        "three": ">=0.134.0"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -4906,6 +5517,27 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -4915,6 +5547,110 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/meshline": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/meshline/-/meshline-3.3.1.tgz",
+      "integrity": "sha512-/TQj+JdZkeSUOl5Mk2J7eLcYTLiQm2IDzmlSvYm7ov15anEcDJ92GHqqazxTSreeNgfnYu24kiEvvv0WlbCdFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.137"
+      }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-1.1.1.tgz",
+      "integrity": "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g==",
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -5246,6 +5982,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.2",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -5341,7 +6094,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5412,6 +6164,12 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/potpack": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
+      "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
+      "license": "ISC"
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -5420,6 +6178,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/promise-worker-transferable": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/promise-worker-transferable/-/promise-worker-transferable-1.0.4.tgz",
+      "integrity": "sha512-bN+0ehEnrXfxV2ZQvU2PetO0n4gqBD4ulq3MI1WOPLgr7/Mg9yRQkX5+0v1vagr74ZTsl7XtzlaYDo2EuCeYJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "is-promise": "^2.1.0",
+        "lie": "^3.0.2"
       }
     },
     "node_modules/prop-types": {
@@ -5432,6 +6200,16 @@
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/punycode": {
@@ -5493,6 +6271,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/react-use-measure": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
+      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
@@ -5516,6 +6309,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -5535,6 +6352,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -5798,7 +6624,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -5811,10 +6636,28 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/shiki": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.0.2.tgz",
+      "integrity": "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.0.2",
+        "@shikijs/engine-javascript": "4.0.2",
+        "@shikijs/engine-oniguruma": "4.0.2",
+        "@shikijs/langs": "4.0.2",
+        "@shikijs/themes": "4.0.2",
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/side-channel": {
@@ -5902,11 +6745,47 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stats-gl": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/stats-gl/-/stats-gl-2.4.2.tgz",
+      "integrity": "sha512-g5O9B0hm9CvnM36+v7SFl39T7hmAlv541tU81ME8YeSb3i1CIP5/QdDeSB3A0la0bKNHpxpwxOVRo2wFTYEosQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/three": "*",
+        "three": "^0.170.0"
+      },
+      "peerDependencies": {
+        "@types/three": "*",
+        "three": "*"
+      }
+    },
+    "node_modules/stats-gl/node_modules/three": {
+      "version": "0.170.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.170.0.tgz",
+      "integrity": "sha512-FQK+LEpYc0fBD+J8g6oSEyyNzjp+Q7Ks1C568WWaoMRLW+TkNNWmenWeGgJjV105Gd+p/2ql1ZcjYvNiPZBhuQ==",
+      "license": "MIT"
+    },
+    "node_modules/stats.js": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/stats.js/-/stats.js-0.17.0.tgz",
+      "integrity": "sha512-hNKz8phvYLPEcRkeG1rsGmV5ChMjKDAWU7/OJJdDErPBNChQXxCo3WZurGpnWc6gZhAzEPFad1aVgyOANH1sMw==",
       "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
@@ -6036,6 +6915,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-bom": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
@@ -6108,6 +7001,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/suspend-react": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
+      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
@@ -6128,6 +7030,44 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/three": {
+      "version": "0.184.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.184.0.tgz",
+      "integrity": "sha512-wtTRjG92pM5eUg/KuUnHsqSAlPM296brTOcLgMRqEeylYTh/CdtvKUvCyyCQTzFuStieWxvZb8mVTMvdPyUpxg==",
+      "license": "MIT"
+    },
+    "node_modules/three-mesh-bvh": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/three-mesh-bvh/-/three-mesh-bvh-0.8.3.tgz",
+      "integrity": "sha512-4G5lBaF+g2auKX3P0yqx+MJC6oVt6sB5k+CchS6Ob0qvH0YIhuUk1eYr7ktsIpY+albCqE80/FVQGV190PmiAg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">= 0.159.0"
+      }
+    },
+    "node_modules/three-stdlib": {
+      "version": "2.36.1",
+      "resolved": "https://registry.npmjs.org/three-stdlib/-/three-stdlib-2.36.1.tgz",
+      "integrity": "sha512-XyGQrFmNQ5O/IoKm556ftwKsBg11TIb301MB5dWNicziQBEs2g3gtOYIf7pFiLa0zI2gUwhtCjv9fmjnxKZ1Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/draco3d": "^1.4.0",
+        "@types/offscreencanvas": "^2019.6.4",
+        "@types/webxr": "^0.5.2",
+        "draco3d": "^1.4.1",
+        "fflate": "^0.6.9",
+        "potpack": "^1.0.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.128.0"
+      }
+    },
+    "node_modules/three-stdlib/node_modules/fflate": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
+      "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
@@ -6190,6 +7130,46 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/troika-three-text": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-text/-/troika-three-text-0.52.4.tgz",
+      "integrity": "sha512-V50EwcYGruV5rUZ9F4aNsrytGdKcXKALjEtQXIOBfhVoZU9VAqZNIoGQ3TMiooVqFAbR1w15T+f+8gkzoFzawg==",
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.2",
+        "troika-three-utils": "^0.52.4",
+        "troika-worker-utils": "^0.52.0",
+        "webgl-sdf-generator": "1.1.1"
+      },
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-three-utils": {
+      "version": "0.52.4",
+      "resolved": "https://registry.npmjs.org/troika-three-utils/-/troika-three-utils-0.52.4.tgz",
+      "integrity": "sha512-NORAStSVa/BDiG52Mfudk4j1FG4jC4ILutB3foPnfGbOeIs9+G5vZLa0pnmnaftZUGm4UwSoqEpWdqvC7zms3A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "three": ">=0.125.0"
+      }
+    },
+    "node_modules/troika-worker-utils": {
+      "version": "0.52.0",
+      "resolved": "https://registry.npmjs.org/troika-worker-utils/-/troika-worker-utils-0.52.0.tgz",
+      "integrity": "sha512-W1CpvTHykaPH5brv5VHLfQo9D1OYuo0cSBEUQFFT/nBUzM8iD6Lq2/tgG/f1OelbAS1WtaTPQzE5uM49egnngw==",
+      "license": "MIT"
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -6234,6 +7214,43 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tunnel-rat": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/tunnel-rat/-/tunnel-rat-0.1.2.tgz",
+      "integrity": "sha512-lR5VHmkPhzdhrM092lI2nACsLO4QubF0/yoOhzX7c+wIpbN1GjHNzCc91QlpxBi+cnx8vVJ+Ur6vL5cEoQPFpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "zustand": "^4.3.2"
+      }
+    },
+    "node_modules/tunnel-rat/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -6390,6 +7407,74 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
@@ -6466,11 +7551,67 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/utility-types": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
+      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/webgl-constants": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-constants/-/webgl-constants-1.1.1.tgz",
+      "integrity": "sha512-LkBXKjU5r9vAW7Gcu3T5u+5cvSvh5WwINdr0C+9jpzVB41cjQAP5ePArDtk/WHYdVj0GefCgM73BA7FlIiNtdg=="
+    },
+    "node_modules/webgl-sdf-generator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/webgl-sdf-generator/-/webgl-sdf-generator-1.1.1.tgz",
+      "integrity": "sha512-9Z0JcMTFxeE+b2x1LJTdnaT8rT8aEp7MVxkNwoycNmJWwPdzoXzMh0BjJSh/AEFP+KPYZUli814h8bJZFIZ2jA==",
+      "license": "MIT"
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -6622,6 +7763,45 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.12.tgz",
+      "integrity": "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,21 +4,28 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "prebuild": "node scripts/fetch-github-stats.mjs",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "fetch-stats": "node scripts/fetch-github-stats.mjs"
   },
   "dependencies": {
+    "@react-three/drei": "^10.7.7",
+    "@react-three/fiber": "^9.6.0",
     "framer-motion": "^12.38.0",
     "next": "16.2.4",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "shiki": "^4.0.2",
+    "three": "^0.184.0"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/three": "^0.184.0",
     "eslint": "^9",
     "eslint-config-next": "16.2.4",
     "tailwindcss": "^4",

--- a/scripts/fetch-github-stats.mjs
+++ b/scripts/fetch-github-stats.mjs
@@ -1,0 +1,105 @@
+// Build-time fetcher for GitHub stats. Falls back to existing JSON on failure
+// so static builds remain reproducible offline.
+import { writeFile, readFile } from "node:fs/promises";
+import path from "node:path";
+
+const USER = "maruyamayasuaki";
+const OUT = path.join(process.cwd(), "lib", "github-stats.json");
+
+async function gh(endpoint) {
+  const res = await fetch(`https://api.github.com${endpoint}`, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      "User-Agent": "portfolio-build",
+    },
+  });
+  if (!res.ok) throw new Error(`${endpoint} → ${res.status}`);
+  return res.json();
+}
+
+async function main() {
+  try {
+    const [user, repos] = await Promise.all([
+      gh(`/users/${USER}`),
+      gh(`/users/${USER}/repos?per_page=100&sort=updated`),
+    ]);
+
+    const ownedRepos = repos.filter((r) => !r.fork);
+
+    // Aggregate languages across the top recently-pushed repos.
+    const topRepos = ownedRepos.slice(0, 12);
+    const languageBuckets = {};
+    await Promise.all(
+      topRepos.map(async (r) => {
+        try {
+          const langs = await gh(`/repos/${USER}/${r.name}/languages`);
+          for (const [k, v] of Object.entries(langs)) {
+            languageBuckets[k] = (languageBuckets[k] || 0) + v;
+          }
+        } catch {
+          /* ignore individual failures */
+        }
+      }),
+    );
+
+    const totalStars = ownedRepos.reduce((s, r) => s + (r.stargazers_count || 0), 0);
+
+    const featured = ownedRepos
+      .sort((a, b) => (b.stargazers_count || 0) - (a.stargazers_count || 0))
+      .slice(0, 8)
+      .map((r) => ({
+        name: r.name,
+        description: r.description,
+        url: r.html_url,
+        stars: r.stargazers_count,
+        forks: r.forks_count,
+        language: r.language,
+        updated: r.pushed_at,
+        topics: r.topics ?? [],
+      }));
+
+    const stats = {
+      generatedAt: new Date().toISOString(),
+      user: {
+        login: user.login,
+        name: user.name,
+        bio: user.bio,
+        publicRepos: user.public_repos,
+        followers: user.followers,
+        following: user.following,
+        avatarUrl: user.avatar_url,
+        htmlUrl: user.html_url,
+      },
+      totals: {
+        stars: totalStars,
+        repos: ownedRepos.length,
+      },
+      languages: Object.fromEntries(
+        Object.entries(languageBuckets).sort((a, b) => b[1] - a[1]),
+      ),
+      featured,
+    };
+
+    await writeFile(OUT, JSON.stringify(stats, null, 2));
+    console.log(`[github-stats] wrote ${OUT}: ${ownedRepos.length} repos, ${Object.keys(languageBuckets).length} languages`);
+  } catch (err) {
+    console.warn(`[github-stats] fetch failed (${err.message}); keeping existing snapshot if any.`);
+    try {
+      await readFile(OUT, "utf8");
+      console.warn("[github-stats] existing snapshot reused.");
+    } catch {
+      // No snapshot — write minimal placeholder so the build doesn't crash.
+      const placeholder = {
+        generatedAt: null,
+        user: { login: USER, name: "Yasuaki Maruyama", bio: null, publicRepos: 0, followers: 0, following: 0, avatarUrl: "", htmlUrl: `https://github.com/${USER}` },
+        totals: { stars: 0, repos: 0 },
+        languages: {},
+        featured: [],
+      };
+      await writeFile(OUT, JSON.stringify(placeholder, null, 2));
+      console.warn("[github-stats] wrote placeholder snapshot.");
+    }
+  }
+}
+
+main();


### PR DESCRIPTION
Builds 5 candidate redesigns (CLI, IDE, Dashboard, Brutalist, MI Lab) as
parallel routes so the owner can compare them side-by-side before picking one.
The original / is left untouched as the baseline. All variants share content
via lib/i18n.ts; heavy deps (three.js, shiki) are lazy-loaded or build-time
only so other routes stay light.

- /variants                 — comparison index with 5 cards
- /variants/cli             — terminal/CLI-style with typing animation
- /variants/ide             — VSCode-style shell, shiki-highlighted at build
- /variants/dashboard       — GitHub-stats dashboard with heatmap/donut/radar
- /variants/brutalist       — README-style high-density, no JS animations
- /variants/mi-lab          — Materials-Informatics 3D Hero (perovskite
                              ABO3 lattice via react-three-fiber) + 1D
                              Bayesian Optimization SVG demo

scripts/fetch-github-stats.mjs runs in prebuild and falls back to the
checked-in lib/github-stats.json when the unauthenticated GitHub API is
rate-limited so CI builds remain reproducible offline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added five portfolio design variants: brutalist, CLI, dashboard, IDE, and laboratory-themed views with distinct visual styles and layouts.
  * Integrated interactive 3D lattice visualization and Bayesian optimization demo.
  * Added contribution heatmap, skill radar, and language distribution charts.
  * Updated footer with link to variants index.

* **Chores**
  * Added GitHub statistics integration during build process.
  * Expanded build dependencies for 3D rendering and syntax highlighting support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->